### PR TITLE
Send correct HTTP status code when missing required params

### DIFF
--- a/api/requests/Request.php
+++ b/api/requests/Request.php
@@ -17,7 +17,7 @@ class Request {
      protected function processRequiredVars($array){
 	  foreach($array as $var){
 	       if(!isset($this->$var) || $this->$var == "" || is_null($this->$var)){	    
-		    throw new Exception("$var not set. Please review your request and add the right parameters",401);
+		    throw new Exception("$var not set. Please review your request and add the right parameters",400);
 	       }
 	  }
      }


### PR DESCRIPTION
I guess this should fix issue #43. I am not a PHP developer so please verify this little tiny change. I guess the 401 code in the `<error code="401">` response tag is loaded dynamically from this value?