### PR TITLE
Add 405 when GET request to the occupancy feedback URL is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Things you will need on the server you want to set it up:
 If you got these things set up you will need to import the data (the structural.csv file) in MongoDB that already exists in the [Spitsgids-data repo](https://github.com/osoc16/Spitsgids-data):
 
 ```
-mongoimport -d spitsgids -c structure --type csv --file structural.csv --headerline
+mongoimport -d spitsgids -c structural --type csv --file structural.csv --headerline
 ```
 
 If you run `mongod` now you should be good to go!

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Things you will need on the server you want to set it up:
   * Preferable with PECL `sudo pecl install mongodb`
   * In case of problems with `Homebrew brew install php70-mongodb`
 
-If you got these things set up you will need to import the data (the structure.csv file) in MongoDB that already exists in the [Spitsgids-data repo](https://github.com/osoc16/Spitsgids-data):
+If you got these things set up you will need to import the data (the structural.csv file) in MongoDB that already exists in the [Spitsgids-data repo](https://github.com/osoc16/Spitsgids-data):
 
 ```
-mongoimport -d spitsgids -c structure --type csv --file structure.csv --headerline
+mongoimport -d spitsgids -c structure --type csv --file structural.csv --headerline
 ```
 
 If you run `mongod` now you should be good to go!

--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ Things you will need on the server you want to set it up:
   * Preferable with PECL `sudo pecl install mongodb`
   * In case of problems with `Homebrew brew install php70-mongodb`
 
-If you got these things set up you will need to import the data (the .csv files) in MongoDB that already exists in the [Spitsgids-data repo](https://github.com/osoc16/Spitsgids-data):
+If you got these things set up you will need to import the data (the structure.csv file) in MongoDB that already exists in the [Spitsgids-data repo](https://github.com/osoc16/Spitsgids-data):
 
 ```
-mongoimport -d spitsgids -c survey --type csv --file survey.csv --headerline
-mongoimport -d spitsgids -c nmbs --type csv --file nmbs.csv --headerline
+mongoimport -d spitsgids -c structure --type csv --file structure.csv --headerline
 ```
 
 If you run `mongod` now you should be good to go!

--- a/api/APIPost.php
+++ b/api/APIPost.php
@@ -17,14 +17,16 @@ class APIPost
     private $postData;
     private $resourcename;
     private $log;
+    private $method;
 
-    public function __construct($resourcename, $postData)
+    public function __construct($resourcename, $postData, $method)
     {
         //Default timezone is Brussels
         date_default_timezone_set('Europe/Brussels');
 
         $this->resourcename = $resourcename;
         $this->postData = json_decode($postData);
+        $this->method = $method;
 
         try {
             $this->log = new Logger('irapi');
@@ -40,12 +42,16 @@ class APIPost
 
     public function writeToMongo($ip)
     {
-        try {
-            if ($this->resourcename == 'occupancy') {
-                $this->occupancyToMongo($ip);
+        if($this->method == "POST") {
+            try {
+                if ($this->resourcename == 'occupancy') {
+                    $this->occupancyToMongo($ip);
+                }
+            } catch (Exception $e) {
+                $this->buildError($e);
             }
-        } catch (Exception $e) {
-            $this->buildError($e);
+        } else {
+            $this->buildError(new Exception('Only post requests are allowed', 405));
         }
     }
 

--- a/api/feedback/occupancy.php
+++ b/api/feedback/occupancy.php
@@ -30,5 +30,5 @@ include_once '../APIPost.php';
 date_default_timezone_set('Europe/Brussels');
 
 $postdata = file_get_contents("php://input");
-$post = new APIPost('occupancy', $postdata);
+$post = new APIPost('occupancy', $postdata, $_SERVER['REQUEST_METHOD']);
 $post->writeToMongo($_SERVER['REMOTE_ADDR']);


### PR DESCRIPTION
When a GET request is done to https://irail.be/feedback/occupancy, a 405 error is returned saying that you can only do post requests.