### PR TITLE
Added `nointernationaltrains` type of transport option

### DIFF
--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -95,6 +95,8 @@ class connections
         ];
         if ($typeOfTransport == 'trains') {
             $trainsonly = '1111111000000000';
+        } elseif ($typeOfTransport == 'nointernationaltrains') {
+            $trainsonly = '0111111000000000';
         } elseif ($typeOfTransport == 'all') {
             $trainsonly = '1111111111111111';
         } else {


### PR DESCRIPTION
This partly fixes #199, allowing to get NMBS connections that do not
use international trains.

I've also been playing around a bit with the idea of having some kind of `TransportType` "enum" class, like

```
class TransportType {
    const TRAINS               = 0b1111111000000000;
    const INTERNATIONAL_TRAINS = 0b1000000000000000;
    const ALL                  = 0b1111111111111111;
}
```

that would allow to use boolean operations like `TransportType::TRAINS & !TransportType::TRAINS` as `TypeOfTransport` parameter. However I do not now how this could be mapped nicely in the API.