### PR TITLE
Connection id will be right even if the parameter has no "BE.NMBS."-prefix in the vehicle GET request

### DIFF
--- a/api/data/NMBS/vehicleinformation.php
+++ b/api/data/NMBS/vehicleinformation.php
@@ -239,7 +239,11 @@ class vehicleinformation
                 $stops[$j]->scheduledArrivalTime = tools::transformTime('0' . $nextDayArrival . 'd'.$arrivalTime.':00', $dateDatetime->format('Ymd'));
                 $stops[$j]->arrivalDelay = $arrivalDelay;
                 $stops[$j]->arrivalCanceled = $arrivalCanceled;
-                $stops[$j]->departureConnection = 'http://irail.be/connections/' . substr(basename($stops[$j]->station->{'@id'}), 2) . '/' . $dateDatetime->format('Ymd') . '/' . substr($vehicle, strrpos($vehicle, '.') + 1);
+
+                $pointInVehicle = strrpos($vehicle, '.');
+                if($pointInVehicle != 0) $pointInVehicle += 1;
+
+                $stops[$j]->departureConnection = 'http://irail.be/connections/' . substr(basename($stops[$j]->station->{'@id'}), 2) . '/' . $dateDatetime->format('Ymd') . '/' . substr($vehicle, $pointInVehicle);
                 $stops[$j]->platform = new Platform();
                 $stops[$j]->platform->name = $platform;
                 $stops[$j]->platform->normal = $normalplatform;


### PR DESCRIPTION
Fixed https://github.com/iRail/iRail/issues/224.