### PR TITLE
add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+php:
+  - "5.5"
+  - "5.6"
+  - "7.0"
+  - hhvm
+sudo: false
+env:
+addons:
+  apt:
+    packages:
+      - nodejs
+before_script:
+  - composer install
+  # - php artisan key:generate
+script:
+  - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_script:
   - composer install
   # - php artisan key:generate
 script:
-  - phpunit
+  - phpunit --exclude-group testDotEnvVars

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # iRail
 
-[![License AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-brightgreen.svg)](http://www.gnu.org/licenses/agpl-3.0.html) [![Join the chat at https://gitter.im/iRail/iRail](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/iRail/iRail?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![License AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-brightgreen.svg)](http://www.gnu.org/licenses/agpl-3.0.html) [![Join the chat at https://gitter.im/iRail/iRail](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/iRail/iRail?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/iRail/iRail.svg)](https://travis-ci.org/iRail/iRail)
 
-iRail supports digital creativity concerning mobility in Belgium. This is an attempt to make the railway time schedules in Belgium easily available for anyone. 
+iRail supports digital creativity concerning mobility in Belgium. This is an attempt to make the railway time schedules in Belgium easily available for anyone.
 
 Our main site consists of a very easy mobile website to look up time schedules using our own API.
 

--- a/tests/configurationTest.php
+++ b/tests/configurationTest.php
@@ -4,6 +4,9 @@ use Dotenv\Dotenv;
 
 class configurationTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @group testDotEnvVars
+     */
     public function testDotEnvVars()
     {
         $dotenv = new Dotenv(dirname(__DIR__));


### PR DESCRIPTION
this is analog to iRail/hyperRail. ~~Travis still has to be enabled by someone with control over this repository.~~

Test 3 still fails though. It's testing for the `.env` file and wants it to contain:

```
apiHost=localhost
apiUser=irail
apiTable=apilog
apiPassword=passwd
column1=id
column2=time
column3=useragent
column4=fromstation
column5=tostation
column6=errors
column7=ip
column8=server
apiServerName=0
```

But it currently contains:

```
MONGODB_URL="mongodb://localhost:27017"
MONGODB_DB="irail"
```

Travis also doesn't have this `.env` file, so maybe an option to exclude this test?
