### PR TITLE
Occupancy in vehicle GET request 

### DIFF
--- a/api/data/NMBS/vehicleinformation.php
+++ b/api/data/NMBS/vehicleinformation.php
@@ -261,7 +261,7 @@ class vehicleinformation
                 $stops[$j]->canceled = $departureCanceled;
 
                 // Check if it is in less than 2 days and MongoDB is available
-                if (!$fast && $isOccupancyDate && isset($occupancyArr)) {
+                if ($isOccupancyDate && isset($occupancyArr)) {
                     // Add occupancy
                     $occupancyOfStationFound = false;
                     $k = 0;


### PR DESCRIPTION
Deleted fast parameter because it doesn't need to be true to put the occupancy in the vehicle GET request. 
