### PR TITLE
fix typo

### DIFF
--- a/api/terms/index.html
+++ b/api/terms/index.html
@@ -18,4 +18,3 @@
     </section>
   </body>
 </html>
-g


### PR DESCRIPTION
Stray g that shouldn't be there in the terms/index