### PR TITLE
Add a 'num' parameter

### DIFF
--- a/api/logs.php
+++ b/api/logs.php
@@ -8,4 +8,10 @@ header('Cache-Control: max-age=1');//expires in 1 second
 header('Content-Type: application/json');
 header('Access-Control-Allow-Origin: *');//allow from every location
 $log = new JsonLog('../storage/irapi.log');
-print json_encode($log->getLastEntries(1000));
+
+$num = 1000;
+if (isset($_GET['num'])) {
+    $num = $_GET['num'];
+}
+
+print json_encode($log->getLastEntries($num));


### PR DESCRIPTION
this will allow lower load on clientside (like datawall) integrations of the iRail logs API. You can then decide a number of logs you find relevant to work with via <http://api.irail.be/logs?num=50> by example.

There's no documentation page for the logs API. Where could that come?