### PR TITLE
Hotfix: Strip alerts from style html, and use json-encode when printing json #283

### DIFF
--- a/api/data/NMBS/vehicleinformation.php
+++ b/api/data/NMBS/vehicleinformation.php
@@ -41,8 +41,8 @@ class vehicleinformation
 
 
         $dataroot->vehicle = self::getVehicleData($html, $request->getVehicleId(), $lang);
-        if ($request->getAlerts() && self::getAlerts($html)) {
-            $dataroot->alert = self::getAlerts($html);
+        if ($request->getAlerts() && self::getAlerts($html, $request->getFormat())) {
+            $dataroot->alert = self::getAlerts($html, $request->getFormat());
         }
 
         $pointInVehicle = strrpos($request->getVehicleId(), '.');
@@ -299,7 +299,7 @@ class vehicleinformation
      * @return null|Alerts
      * @throws Exception
      */
-    private static function getAlerts($html)
+    private static function getAlerts($html, $format)
     {
         $test = $html->getElementById('tq_trainroute_content_table_alteAnsicht');
         if (! is_object($test)) {
@@ -322,6 +322,14 @@ class vehicleinformation
             $alert = new Alert();
             $alert->header = trim($header);
             $alert->description = trim($alertelements[1]);
+
+            // Keep <a> elements, those are valueable
+            $alert->description = strip_tags($alert->description, '<a>');
+
+            // Only encode json, since xml can use CDATA. Trim ", since these are added later on.
+            if ($format == 'json') {
+                $alert->description = trim(json_encode($alert->description), '"');
+            }
 
             array_push($alerts, $alert);
         }


### PR DESCRIPTION
Bug fix for #283.

#### Changes 

* Strip style tags, but keep <a> tags since they might contain valuable information. 
* When printing as json, json encode the alert description. 
