### PR TITLE
Include "left" property for every train stop, to indicate if the trai…

### DIFF
--- a/api/data/NMBS/vehicleinformation.php
+++ b/api/data/NMBS/vehicleinformation.php
@@ -140,7 +140,7 @@ class vehicleinformation
 
                 $arrivalDelay = trim($delayelements[0]);
                 $arrivalCanceled = false;
-                if (!$arrivalDelay) {
+                if (! $arrivalDelay) {
                     $arrivalDelay = 0;
                 } elseif (stripos($arrivalDelay, '+') !== false) {
                     $arrivalDelay = preg_replace('/[^0-9]/', '', $arrivalDelay) * 60;
@@ -151,7 +151,7 @@ class vehicleinformation
 
                 $departureDelay = trim($delayelements[1]);
                 $departureCanceled = false;
-                if (!$departureDelay) {
+                if (! $departureDelay) {
                     $departureDelay = $arrivalDelay ? $arrivalDelay : 0;
                 } elseif (stripos($departureDelay, '+') !== false) {
                     $departureDelay = preg_replace('/[^0-9]/', '', $departureDelay) * 60;
@@ -161,11 +161,25 @@ class vehicleinformation
                 }
 
                 // Departed
-                $departureImgNode = $node->children[0]->children[0];
+                // Based on timeline images on the NMBS site.
+                // A filled timeline, meaning arrived/departed, has an image ending in "reported.png".
+                // Example:
+                // <img src="/as/hafas-res/img/pearl/realtime_pearl_middle_arr_dep_reported.png" alt="" title="" width="20" height="44">
+                if (isset($node->children[0]) && isset($node->children[0]->children[0])) {
+                    $departureImgNode = $node->children[0]->children[0];
 
-                if (strpos($departureImgNode->attr['src'], 'reported.png') !== false) {
-                    $departed = true;
+                    // Check if this element has a src attribute.
+                    if (key_exists('src', $departureImgNode->attr) &&
+                        strpos($departureImgNode->attr['src'], 'reported.png') !== false) {
+                        $departed = true;
+                    } else {
+                        // Default to false if we don't have any information. This keeps API output consistent.
+                        // (Always include the field)
+                        $departed = false;
+                    }
                 } else {
+                    // Default to false if we don't have any information. This keeps API output consistent.
+                    // (Always include the field)
                     $departed = false;
                 }
 

--- a/api/data/NMBS/vehicleinformation.php
+++ b/api/data/NMBS/vehicleinformation.php
@@ -160,6 +160,15 @@ class vehicleinformation
                     $departureCanceled = true;
                 }
 
+                // Departed
+                $departureImgNode = $node->children[0]->children[0];
+
+                if (strpos($departureImgNode->attr['src'], 'reported.png') !== false) {
+                    $departed = true;
+                } else {
+                    $departed = false;
+                }
+
                 // Time
                 $timenodearray = $node->children[1]->find('span');
                 $arrivalTime = reset($timenodearray[0]->nodes[0]->_);
@@ -259,6 +268,7 @@ class vehicleinformation
                 $stops[$j]->time = tools::transformTime('0' . $nextDay . 'd'.$departureTime.':00', $dateDatetime->format('Ymd'));
                 $stops[$j]->delay = $departureDelay;
                 $stops[$j]->canceled = $departureCanceled;
+                $stops[$j]->left = $departed;
 
                 // Check if it is in less than 2 days and MongoDB is available
                 if ($fast != 'true' && $isOccupancyDate && isset($occupancyArr)) {


### PR DESCRIPTION
Include "left" property for every train stop, to indicate if the train has reached the station yet. Addresses issue #92. 
Based on the red line next to the train on [the train search page](http://www.belgianrail.be/jp/sncb-nmbs-routeplanner/traininfo.exe/nn/920409/307271/37498/288057/80?ld=std&AjaxMap=CPTVMap&date=09/06/2017&station_evaId=8892007&station_type=dep&input=8892007&boardType=dep&time=12:01&maxJourneys=50&dateBegin=09/06/2017&dateEnd=09/06/2017&selectDate=&productsFilter=0111111&dirInput=&backLink=sq&).

This can either be merged in to development or master, but as soon as it's tested/verified by someone else, this can go in production.

Note: the current locationX and locationY fields are still showing the coördinates of the first stop.
Note: The field has been called "left", to stay consistent with naming on other pages. The NMBS seems to indicate both arrival and departure with this field. I'm open for better naming suggestions.