### PR TITLE
Fixed check if vehicle information is available, and show an appropriate message if it's not #275

### DIFF
--- a/api/data/NMBS/vehicleinformation.php
+++ b/api/data/NMBS/vehicleinformation.php
@@ -453,7 +453,7 @@ class vehicleinformation
 
     private static function trainDrives($html)
     {
-        return $html && is_object($html->getElementById('HFSResult')->getElementByTagName('table'));
+        return $html && is_object($html->getElementById('HFSResult')) && is_object($html->getElementById('HFSResult')->getElementByTagName('table'));
     }
 
     private static function parseCorrectUrl($html)


### PR DESCRIPTION
NMBS Vehicle data validation should be more prone against crashes now