### PR TITLE
Feature/309 via departing vehicle

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-MONGODB_URL="mongodb://localhost:27017"
-MONGODB_DB="irail"

--- a/api/APIPost.php
+++ b/api/APIPost.php
@@ -79,7 +79,6 @@ class APIPost
         if (!is_null($this->postData->connection) && !is_null($this->postData->from) && !is_null($this->postData->date) && !is_null($this->postData->vehicle) && !is_null($this->postData->occupancy)) {
             if (OccupancyOperations::isCorrectPostURI($this->postData->occupancy)) {
                 try {
-
                     if (! in_array($this->postData->occupancy,
                         [OccupancyOperations::LOW, OccupancyOperations::MEDIUM, OccupancyOperations::HIGH])
                     ) {
@@ -142,7 +141,6 @@ class APIPost
                     $this->writeLog($postInfo);
 
                     OccupancyDao::processFeedback($postInfo);
-
                 } catch (Exception $e) {
                     $this->buildError($e);
                 }

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -320,6 +320,8 @@ class connections
                     $k = 0;
                     foreach ($conn->ConSectionList->ConSection as $connsection) {
                         if (isset($connsection->Journey->JourneyAttributeList->JourneyAttribute)) {
+                            $j++;
+                            $k++;
                             if ($conn->Overview->Transfers > 0 && strcmp($connsection->Arrival->BasicStop->Station['name'], $conn->Overview->Arrival->BasicStop->Station['name']) != 0) {
                                 //current index for the train: j-1
                                 $connarray = $conn->ConSectionList->ConSection;

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -381,7 +381,13 @@ class connections
                                 } else {
                                     $vias[$connectionindex]->direction = 'unknown';
                                 }
+                                if (isset($directions[$k])) {
+                                    $vias[$connectionindex]->departingDirection = $directions[$k];
+                                } else {
+                                    $vias[$connectionindex]->departingDirection = 'unknown';
+                                }
                                 $vias[$connectionindex]->vehicle = 'BE.NMBS.'.$trains[$j - 1];
+                                $vias[$connectionindex]->departingVehicle = 'BE.NMBS.'.$trains[$j];
                                 $vias[$connectionindex]->station = self::getStationFromHafasDescription($connsection->Arrival->BasicStop->Station['name'], $connsection->Arrival->BasicStop->Station['x'], $connsection->Arrival->BasicStop->Station['y'], $lang);
                                 $vias[$connectionindex]->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->vehicle, strrpos($vias[$connectionindex]->vehicle, '.') + 1);
                                 $connectionindex++;

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -388,8 +388,10 @@ class connections
                                 $vias[$connectionindex]->timeBetween = $departTime - $arrivalTime;
                                 if (isset($directions[$k - 1])) {
                                     $vias[$connectionindex]->direction = $directions[$k - 1];
+                                    $vias[$connectionindex]->arrival->direction = $directions[$k - 1];
                                 } else {
                                     $vias[$connectionindex]->direction = 'unknown';
+                                    $vias[$connectionindex]->arrival->direction = 'unknown';
                                 }
                                 if (isset($directions[$k])) {
                                     $vias[$connectionindex]->departure->direction = $directions[$k];
@@ -397,9 +399,11 @@ class connections
                                     $vias[$connectionindex]->departure->direction = 'unknown';
                                 }
                                 $vias[$connectionindex]->vehicle = 'BE.NMBS.'.$trains[$j - 1];
+                                $vias[$connectionindex]->arrival->vehicle = 'BE.NMBS.'.$trains[$j - 1];
                                 $vias[$connectionindex]->departure->vehicle = 'BE.NMBS.' . $trains[$j];
                                 $vias[$connectionindex]->station = self::getStationFromHafasDescription($connsection->Arrival->BasicStop->Station['name'], $connsection->Arrival->BasicStop->Station['x'], $connsection->Arrival->BasicStop->Station['y'], $lang);
-                                $vias[$connectionindex]->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->vehicle, strrpos($vias[$connectionindex]->vehicle, '.') + 1);
+                                $vias[$connectionindex]->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->departure->vehicle, strrpos($vias[$connectionindex]->departure->vehicle, '.') + 1);
+                                $vias[$connectionindex]->arrival->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->departure->vehicle, strrpos($vias[$connectionindex]->arrival->vehicle, '.') + 1);
                                 $connectionindex++;
                             }
                         }

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -308,12 +308,18 @@ class connections
                                 } elseif ($att->Attribute['type'] == 'DIRECTION') {
                                     $__stat = new stdClass();
                                     //This recently changed: only fetch direction name, nothing else.
-                                    $__stat->name = str_replace(' [NMBS/SNCB]', '', trim($att->Attribute->AttributeVariant->Text));
+                                    $__stat->name = str_replace(' [NMBS/SNCB]', '',
+                                        trim($att->Attribute->AttributeVariant->Text));
                                     $directions[$k] = $__stat;
                                     $k++;
                                 }
                             }
-
+                        }
+                    }
+                    $j = 0;
+                    $k = 0;
+                    foreach ($conn->ConSectionList->ConSection as $connsection) {
+                        if (isset($connsection->Journey->JourneyAttributeList->JourneyAttribute)) {
                             if ($conn->Overview->Transfers > 0 && strcmp($connsection->Arrival->BasicStop->Station['name'], $conn->Overview->Arrival->BasicStop->Station['name']) != 0) {
                                 //current index for the train: j-1
                                 $connarray = $conn->ConSectionList->ConSection;
@@ -387,7 +393,7 @@ class connections
                                     $vias[$connectionindex]->departingDirection = 'unknown';
                                 }
                                 $vias[$connectionindex]->vehicle = 'BE.NMBS.'.$trains[$j - 1];
-                                $vias[$connectionindex]->departingVehicle = 'BE.NMBS.'.$trains[$j];
+                                $vias[$connectionindex]->departingVehicle = 'BE.NMBS.' . $trains[$j];
                                 $vias[$connectionindex]->station = self::getStationFromHafasDescription($connsection->Arrival->BasicStop->Station['name'], $connsection->Arrival->BasicStop->Station['x'], $connsection->Arrival->BasicStop->Station['y'], $lang);
                                 $vias[$connectionindex]->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->vehicle, strrpos($vias[$connectionindex]->vehicle, '.') + 1);
                                 $connectionindex++;

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -410,7 +410,7 @@ class connections
                                 $vias[$connectionindex]->departure->vehicle = 'BE.NMBS.' . $trains[$j];
                                 $vias[$connectionindex]->station = self::getStationFromHafasDescription($connsection->Arrival->BasicStop->Station['name'], $connsection->Arrival->BasicStop->Station['x'], $connsection->Arrival->BasicStop->Station['y'], $lang);
                                 $vias[$connectionindex]->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->departure->vehicle, strrpos($vias[$connectionindex]->departure->vehicle, '.') + 1);
-                                $vias[$connectionindex]->arrival->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->departure->vehicle, strrpos($vias[$connectionindex]->arrival->vehicle, '.') + 1);
+                                $vias[$connectionindex]->arrival->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->arrival->vehicle, strrpos($vias[$connectionindex]->arrival->vehicle, '.') + 1);
                                 $connectionindex++;
                             }
                         }

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -386,18 +386,25 @@ class connections
                                 $vias[$connectionindex]->departure->platform->normal = $departPlatformNormal;
                                 $vias[$connectionindex]->departure->canceled = $departcanceled;
                                 $vias[$connectionindex]->timeBetween = $departTime - $arrivalTime;
+
                                 if (isset($directions[$k - 1])) {
                                     $vias[$connectionindex]->direction = $directions[$k - 1];
-                                    $vias[$connectionindex]->arrival->direction = $directions[$k - 1];
+
+                                    // If wanted, we can drop in full station information without breaking any compatibility. Requires more (CPU) time though.
+                                    $vias[$connectionindex]->arrival->direction = Stations::getStationFromName($directions[$k-1]->name,$lang);
+                                    // $vias[$connectionindex]->arrival->direction = $directions[$k];
                                 } else {
                                     $vias[$connectionindex]->direction = 'unknown';
                                     $vias[$connectionindex]->arrival->direction = 'unknown';
                                 }
                                 if (isset($directions[$k])) {
-                                    $vias[$connectionindex]->departure->direction = $directions[$k];
+                                    // If wanted, we can drop in full station information without breaking any compatibility. Requires more (CPU) time though.
+                                    $vias[$connectionindex]->departure->direction = Stations::getStationFromName($directions[$k]->name,$lang);;
+                                    // $vias[$connectionindex]->departure->direction = $directions[$k];
                                 } else {
                                     $vias[$connectionindex]->departure->direction = 'unknown';
                                 }
+
                                 $vias[$connectionindex]->vehicle = 'BE.NMBS.'.$trains[$j - 1];
                                 $vias[$connectionindex]->arrival->vehicle = 'BE.NMBS.'.$trains[$j - 1];
                                 $vias[$connectionindex]->departure->vehicle = 'BE.NMBS.' . $trains[$j];

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -390,17 +390,16 @@ class connections
                                     $vias[$connectionindex]->direction = $directions[$k - 1];
 
                                     // If wanted, we can drop in full station information without breaking any compatibility. Requires more (CPU) time though.
-                                    $vias[$connectionindex]->arrival->direction = Stations::getStationFromName($directions[$k-1]->name, $lang);
-                                    // $vias[$connectionindex]->arrival->direction = $directions[$k];
+                                    // $vias[$connectionindex]->arrival->direction = Stations::getStationFromName($directions[$k-1]->name, $lang);
+                                    $vias[$connectionindex]->arrival->direction = $directions[$k - 1];
                                 } else {
                                     $vias[$connectionindex]->direction = 'unknown';
                                     $vias[$connectionindex]->arrival->direction = 'unknown';
                                 }
                                 if (isset($directions[$k])) {
                                     // If wanted, we can drop in full station information without breaking any compatibility. Requires more (CPU) time though.
-                                    $vias[$connectionindex]->departure->direction = Stations::getStationFromName($directions[$k]->name, $lang);
-                                    ;
-                                    // $vias[$connectionindex]->departure->direction = $directions[$k];
+                                    //$vias[$connectionindex]->departure->direction = Stations::getStationFromName($directions[$k]->name, $lang);
+                                    $vias[$connectionindex]->departure->direction = $directions[$k];
                                 } else {
                                     $vias[$connectionindex]->departure->direction = 'unknown';
                                 }

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -320,8 +320,10 @@ class connections
                     $k = 0;
                     foreach ($conn->ConSectionList->ConSection as $connsection) {
                         if (isset($connsection->Journey->JourneyAttributeList->JourneyAttribute)) {
+
                             $j++;
                             $k++;
+
                             if ($conn->Overview->Transfers > 0 && strcmp($connsection->Arrival->BasicStop->Station['name'], $conn->Overview->Arrival->BasicStop->Station['name']) != 0) {
                                 //current index for the train: j-1
                                 $connarray = $conn->ConSectionList->ConSection;
@@ -390,12 +392,12 @@ class connections
                                     $vias[$connectionindex]->direction = 'unknown';
                                 }
                                 if (isset($directions[$k])) {
-                                    $vias[$connectionindex]->departingDirection = $directions[$k];
+                                    $vias[$connectionindex]->departure->direction = $directions[$k];
                                 } else {
-                                    $vias[$connectionindex]->departingDirection = 'unknown';
+                                    $vias[$connectionindex]->departure->direction = 'unknown';
                                 }
                                 $vias[$connectionindex]->vehicle = 'BE.NMBS.'.$trains[$j - 1];
-                                $vias[$connectionindex]->departingVehicle = 'BE.NMBS.' . $trains[$j];
+                                $vias[$connectionindex]->departure->vehicle = 'BE.NMBS.' . $trains[$j];
                                 $vias[$connectionindex]->station = self::getStationFromHafasDescription($connsection->Arrival->BasicStop->Station['name'], $connsection->Arrival->BasicStop->Station['x'], $connsection->Arrival->BasicStop->Station['y'], $lang);
                                 $vias[$connectionindex]->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($vias[$connectionindex]->station->{'@id'}), 2) . '/' . date('Ymd', $departTime) . '/' . substr($vias[$connectionindex]->vehicle, strrpos($vias[$connectionindex]->vehicle, '.') + 1);
                                 $connectionindex++;

--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -320,7 +320,6 @@ class connections
                     $k = 0;
                     foreach ($conn->ConSectionList->ConSection as $connsection) {
                         if (isset($connsection->Journey->JourneyAttributeList->JourneyAttribute)) {
-
                             $j++;
                             $k++;
 
@@ -391,7 +390,7 @@ class connections
                                     $vias[$connectionindex]->direction = $directions[$k - 1];
 
                                     // If wanted, we can drop in full station information without breaking any compatibility. Requires more (CPU) time though.
-                                    $vias[$connectionindex]->arrival->direction = Stations::getStationFromName($directions[$k-1]->name,$lang);
+                                    $vias[$connectionindex]->arrival->direction = Stations::getStationFromName($directions[$k-1]->name, $lang);
                                     // $vias[$connectionindex]->arrival->direction = $directions[$k];
                                 } else {
                                     $vias[$connectionindex]->direction = 'unknown';
@@ -399,7 +398,8 @@ class connections
                                 }
                                 if (isset($directions[$k])) {
                                     // If wanted, we can drop in full station information without breaking any compatibility. Requires more (CPU) time though.
-                                    $vias[$connectionindex]->departure->direction = Stations::getStationFromName($directions[$k]->name,$lang);;
+                                    $vias[$connectionindex]->departure->direction = Stations::getStationFromName($directions[$k]->name, $lang);
+                                    ;
                                     // $vias[$connectionindex]->departure->direction = $directions[$k];
                                 } else {
                                     $vias[$connectionindex]->departure->direction = 'unknown';


### PR DESCRIPTION
Include direction and vehicle information for both arrival and departure at a via station

Old situation: each via had a direction and vehicle entry containing information about the arriving vehicle.

New situation: old fields are retained for backwards compatibility. via/departure and via/arrival both get direction and vehicle fields. Vehicle is the id of the vehicle (BE.NMBS.IC817), while departure is a complete station object (name, id, @id).

Benefits:
- No additional compute time, except for looking up the stations. Since these lookups are cached, there is no noticable difference in compute time.
- Way easier to use data: no need to look forward/backward in vias. In the old situation users had to take the arrival and departure field into consideration with the vias, now they can directly use the via data (e.g. in frameworks, serializers/deserializers, ...). Example code which is only possible with this feature: https://github.com/iRail/hyperRail/pull/263

Example new API output for connection via:

```
{
    "id": "0",
    "arrival": {
        "time": "1506085020",
        "platform": "16",
        "platforminfo": {
            "name": "16",
            "normal": "1"
        },
        "delay": "120",
        "canceled": "0",
        "direction": {
            "id": "BE.NMBS.008833001",
            "locationX": "4.715866",
            "locationY": "50.88228",
            "@id": "http://irail.be/stations/NMBS/008833001",
            "standardname": "Leuven",
            "name": "Leuven"
        },
        "vehicle": "BE.NMBS.S23764",
        "departureConnection": "http://irail.be/connections/8814001/20170922/S23764"
    },
    "departure": {
        "time": "1506085560",
        "platform": "15",
        "platforminfo": {
            "name": "15",
            "normal": "1"
        },
        "delay": "180",
        "canceled": "0",
        "direction": {
            "id": "BE.NMBS.008891702",
            "locationX": "2.925809",
            "locationY": "51.228212",
            "@id": "http://irail.be/stations/NMBS/008891702",
            "standardname": "Oostende",
            "name": "Oostende"
        },
        "vehicle": "BE.NMBS.IC536",
        "departureConnection": "http://irail.be/connections/8814001/20170922/IC536",
        "occupancy": {
            "@id": "http://api.irail.be/terms/medium",
            "name": "medium"
        }
    },
    "timeBetween": "540",
    "station": "Brussels-South/Brussels-Midi",
    "stationinfo": {
        "id": "BE.NMBS.008814001",
        "locationX": "4.336531",
        "locationY": "50.835707",
        "@id": "http://irail.be/stations/NMBS/008814001",
        "name": "Brussels-South/Brussels-Midi",
        "standardname": "Brussel-Zuid/Bruxelles-Midi"
    },
    "vehicle": "BE.NMBS.S23764",
    "direction": {
        "name": "Leuven"
    }
}
```