### PR TITLE
Hotfix/311 liveboard alerts json

### DIFF
--- a/api/APIPost.php
+++ b/api/APIPost.php
@@ -79,7 +79,6 @@ class APIPost
         if (!is_null($this->postData->connection) && !is_null($this->postData->from) && !is_null($this->postData->date) && !is_null($this->postData->vehicle) && !is_null($this->postData->occupancy)) {
             if (OccupancyOperations::isCorrectPostURI($this->postData->occupancy)) {
                 try {
-
                     if (! in_array($this->postData->occupancy,
                         [OccupancyOperations::LOW, OccupancyOperations::MEDIUM, OccupancyOperations::HIGH])
                     ) {
@@ -142,7 +141,6 @@ class APIPost
                     $this->writeLog($postInfo);
 
                     OccupancyDao::processFeedback($postInfo);
-
                 } catch (Exception $e) {
                     $this->buildError($e);
                 }

--- a/api/output/Printer.php
+++ b/api/output/Printer.php
@@ -75,11 +75,14 @@ abstract class Printer
         if (is_array($val)) {
             if (count($val) > 0) {
                 $this->startArray($key, count($val), $root);
+                $i = 0;
                 foreach ($val as $elementval) {
                     $this->printElement($key, $elementval);
-                    if ($val[count($val) - 1] != $elementval) {
+                    // Keep count of where we are, and as long as this isn't the last element, print the array divider
+                    if ($i < (count($val)-1)) {
                         $this->nextArrayElement();
                     }
+                    $i++;
                 }
                 $this->endArray($key, $root);
             } else {


### PR DESCRIPTION
Elements were compared by value to determine if it was the last element in the array. This caused trouble in case of identical entries: the first element would be considered to be an end element as well and no array divider would be printed. By keeping track based on a counter, this problem is averted.

The iRail codebase on github might have diverted too much from the old server at this point to just pull the latest code on the old server. @pietercolpaert or @brechtvdv, maybe you can modify the printer.php file on the old server based on the changes I made here?

These changes will automaticly be applied on the new server on monday by merging to development/master.