### PR TITLE
Feature/326 offline data

### DIFF
--- a/api/data/NMBS/disturbances.php
+++ b/api/data/NMBS/disturbances.php
@@ -22,7 +22,7 @@ class disturbances
             $data = self::parseData($xml);
 
             // Store a backup copy to deal with nmbs outages
-            tools::setCachedObject(self::getNmbsCacheKeyLongStorage($request->getLang()),$data,1800);
+            tools::setCachedObject(self::getNmbsCacheKeyLongStorage($request->getLang()),$data,3600);
 
         } catch (Exception $exception) {
             $data = tools::getCachedObject(self::getNmbsCacheKeyLongStorage($request->getLang()));
@@ -34,7 +34,7 @@ class disturbances
 
             $disturbance = new stdClass();
             $disturbance->title = "Website issues";
-            $disturbance->description = "It seems there are problems with the website. Routeplanning or live data might not be available.";
+            $disturbance->description = "It seems there are problems with the NMBS/SNCB website. Routeplanning or live data might not be available.";
             $disturbance->link = "https://belgianrail.be/";
             $disturbance->timestamp = round(microtime(true));
             array_unshift($data,$disturbance);

--- a/api/data/NMBS/disturbances.php
+++ b/api/data/NMBS/disturbances.php
@@ -13,18 +13,51 @@ class disturbances
     {
         $nmbsCacheKey = self::getNmbsCacheKey($request->getLang());
         $xml = tools::getCachedObject($nmbsCacheKey);
-        if ($xml === false) {
-            $xml = self::fetchData($request->getLang());
-            tools::setCachedObject($nmbsCacheKey, $xml);
+
+        try {
+            if ($xml === false) {
+                $xml = self::fetchData($request->getLang());
+                tools::setCachedObject($nmbsCacheKey, $xml);
+            }
+            $data = self::parseData($xml);
+
+            // Store a backup copy to deal with nmbs outages
+            tools::setCachedObject(self::getNmbsCacheKeyLongStorage($request->getLang()),$data,1800);
+
+        } catch (Exception $exception) {
+            $data = tools::getCachedObject(self::getNmbsCacheKeyLongStorage($request->getLang()));
+
+            if ($data === false){
+                // No cached copy available
+                throw $exception;
+            }
+
+            $disturbance = new stdClass();
+            $disturbance->title = "Website issues";
+            $disturbance->description = "It seems there are problems with the website. Routeplanning or live data might not be available.";
+            $disturbance->link = "https://belgianrail.be/";
+            $disturbance->timestamp = round(microtime(true));
+            array_unshift($data,$disturbance);
         }
 
-        $data = self::parseData($xml);
         $dataroot->disturbance = $data;
     }
 
     public static function getNmbsCacheKey($lang)
     {
         return 'NMBSDisturbances|' . $lang;
+    }
+
+    /**
+     * A second key, where we store results for 30 minutes. This way we can still provide data when the NMBS goes
+     * offline.
+     *
+     * @param $lang
+     * @return string
+     */
+    public static function getNmbsCacheKeyLongStorage($lang)
+    {
+        return 'NMBSDisturbances|' . $lang . '|backup';
     }
 
     /**

--- a/api/data/NMBS/tools.php
+++ b/api/data/NMBS/tools.php
@@ -143,10 +143,11 @@ class tools
     /**
      * Store an item in the cache
      *
-     * @param String        $key   The key to store the object under
-     * @param object|string $value The object to store
+     * @param String              $key   The key to store the object under
+     * @param object|array|string $value The object to store
+     * @param int                 $ttl   The number of seconds to keep this in cache
      */
-    public static function setCachedObject($key, $value)
+    public static function setCachedObject($key, $value, $ttl = self::cache_TTL)
     {
         $key = self::cache_prefix . $key;
 
@@ -154,8 +155,8 @@ class tools
         $item = self::$cache->getItem($key);
 
         $item->set($value);
-        if (self::cache_TTL > 0) {
-            $item->expiresAfter(self::cache_TTL);
+        if ($ttl > 0) {
+            $item->expiresAfter($ttl);
         }
 
         self::$cache->save($item);


### PR DESCRIPTION
Keep the disturbances endpoint online even if the NMBS website goes offline, so we can keep travelers informed. When the NMBS website is offline, we add our own "disturbance" explaining that there are website issues.