### PR TITLE
Avoid high-speed trains when both departure and destination are in Belgium

### DIFF
--- a/api/data/NMBS/connections.php
+++ b/api/data/NMBS/connections.php
@@ -148,9 +148,9 @@ class connections
             } else {
                 $typeOfTransportCode = self::TYPE_TRANSPORT_ALL;
             }
-        } else if ($typeOfTransport == 'nointernationaltrains') {
+        } elseif ($typeOfTransport == 'nointernationaltrains') {
             $typeOfTransportCode = self::TYPE_TRANSPORT_NO_INTERNATIONAL_TRAINS;
-        } else if ($typeOfTransport == 'all') {
+        } elseif ($typeOfTransport == 'all') {
             $typeOfTransportCode = self::TYPE_TRANSPORT_ALL;
         } else {
             // All trains is the default
@@ -554,7 +554,7 @@ class connections
                 if (key_exists('dPlatfR', $conn['dep'])) {
                     $departurePlatform = $conn['dep']['dPlatfR'];
                     $departurePlatformNormal = false;
-                } else if (key_exists('dPlatfS', $conn['dep'])) {
+                } elseif (key_exists('dPlatfS', $conn['dep'])) {
                     $departurePlatform = $conn['dep']['dPlatfS'];
                     $departurePlatformNormal = true;
                 } else {
@@ -580,7 +580,7 @@ class connections
                 if (key_exists('aPlatfR', $conn['arr'])) {
                     $arrivalPlatform = $conn['arr']['aPlatfR'];
                     $arrivalPlatformNormal = false;
-                } else if (key_exists('aPlatfS', $conn['arr'])) {
+                } elseif (key_exists('aPlatfS', $conn['arr'])) {
                     $arrivalPlatform = $conn['arr']['aPlatfS'];
                     $arrivalPlatformNormal = true;
                 } else {
@@ -617,7 +617,7 @@ class connections
                     if (key_exists('dPlatfR', $trainRide['dep'])) {
                         $departPlatform = $trainRide['dep']['dPlatfR'];
                         $departPlatformNormal = false;
-                    } else if (key_exists('dPlatfS', $trainRide['dep'])) {
+                    } elseif (key_exists('dPlatfS', $trainRide['dep'])) {
                         $departPlatform = $trainRide['dep']['dPlatfS'];
                         $departPlatformNormal = true;
                     } else {
@@ -642,7 +642,7 @@ class connections
                     if (key_exists('aPlatfR', $trainRide['arr'])) {
                         $arrivalPlatform = $trainRide['arr']['aPlatfR'];
                         $arrivalPlatformNormal = false;
-                    } else if (key_exists('aPlatfS', $trainRide['arr'])) {
+                    } elseif (key_exists('aPlatfS', $trainRide['arr'])) {
                         $arrivalPlatform = $trainRide['arr']['aPlatfS'];
                         $arrivalPlatformNormal = true;
                     } else {
@@ -862,7 +862,8 @@ class connections
                     $trainIndex++;
                 }
 
-                $connection[$i]->departure->canceled = $trains[0]->departure->canceled;;
+                $connection[$i]->departure->canceled = $trains[0]->departure->canceled;
+                ;
                 $connection[$i]->arrival->canceled = end($trains)->arrival->canceled;
 
                 // Don't need this variable anymore. Clean up for easier debugging.

--- a/api/data/NMBS/liveboard.php
+++ b/api/data/NMBS/liveboard.php
@@ -38,7 +38,7 @@ class liveboard
 
             $dataroot->arrival = self::parseData($html, $request->getTime(), $request->getLang(), $request->isFast(),
                 $request->getAlerts(), null, $request->getFormat());
-        } else if (strtoupper(substr($request->getArrdep(), 0, 1)) == 'D') {
+        } elseif (strtoupper(substr($request->getArrdep(), 0, 1)) == 'D') {
             $nmbsCacheKey = self::getNmbsCacheKey($dataroot->station, $request->getTime(), $request->getDate(),
                 $request->getLang(), 'dep');
             $html = Tools::getCachedObject($nmbsCacheKey);
@@ -327,7 +327,7 @@ class liveboard
             if (key_exists('dTimeR', $stop['stbStop'])) {
                 $delay = tools::calculateSecondsHHMMSS($stop['stbStop']['dTimeR'],
                     $date, $stop['stbStop']['dTimeS'], $date);
-            } else if (key_exists('aTimeR', $stop['stbStop'])) {
+            } elseif (key_exists('aTimeR', $stop['stbStop'])) {
                 $delay = tools::calculateSecondsHHMMSS($stop['stbStop']['aTimeR'],
                     $date, $stop['stbStop']['aTimeS'], $date);
             } else {
@@ -342,7 +342,7 @@ class liveboard
                 if (key_exists('dPlatfR', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['dPlatfR'];
                     $isPlatformNormal = false;
-                } else if (key_exists('dPlatfS', $stop['stbStop'])) {
+                } elseif (key_exists('dPlatfS', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['dPlatfS'];
                     $isPlatformNormal = true;
                 } else {
@@ -358,7 +358,7 @@ class liveboard
                 if (key_exists('aPlatfR', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['aPlatfR'];
                     $isPlatformNormal = false;
-                } else if (key_exists('aPlatfS', $stop['stbStop'])) {
+                } elseif (key_exists('aPlatfS', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['aPlatfS'];
                     $isPlatformNormal = true;
                 } else {
@@ -391,7 +391,7 @@ class liveboard
                 if (key_exists('dCncl', $stop['stbStop'])) {
                     $stopCanceled = $stop['stbStop']['dCncl'];
                 }
-            } else if (key_exists('aProgType', $stop['stbStop'])) {
+            } elseif (key_exists('aProgType', $stop['stbStop'])) {
                 if ($stop['stbStop']['aProgType'] == 'REPORTED') {
                     $left = 1;
                 }

--- a/api/data/NMBS/liveboard.php
+++ b/api/data/NMBS/liveboard.php
@@ -38,7 +38,7 @@ class liveboard
 
             $dataroot->arrival = self::parseData($html, $request->getTime(), $request->getLang(), $request->isFast(),
                 $request->getAlerts(), null, $request->getFormat());
-        } elseif (strtoupper(substr($request->getArrdep(), 0, 1)) == 'D') {
+        } else if (strtoupper(substr($request->getArrdep(), 0, 1)) == 'D') {
             $nmbsCacheKey = self::getNmbsCacheKey($dataroot->station, $request->getTime(), $request->getDate(),
                 $request->getLang(), 'dep');
             $html = Tools::getCachedObject($nmbsCacheKey);
@@ -115,7 +115,7 @@ class liveboard
           }
         ],
         "stbLoc": {
-          "lid": "A=1@O=' . $station->name . '@U=80@L=00' . $station->getHID() . '@B=1@p=1429490515@",
+          "lid": "A=1@O=' . $station->name . '@U=80@L=00' . $station->hafasId . '@B=1@p=1429490515@",
           "name": "' . $station->name . '",
           "type": "S"
         },
@@ -327,7 +327,7 @@ class liveboard
             if (key_exists('dTimeR', $stop['stbStop'])) {
                 $delay = tools::calculateSecondsHHMMSS($stop['stbStop']['dTimeR'],
                     $date, $stop['stbStop']['dTimeS'], $date);
-            } elseif (key_exists('aTimeR', $stop['stbStop'])) {
+            } else if (key_exists('aTimeR', $stop['stbStop'])) {
                 $delay = tools::calculateSecondsHHMMSS($stop['stbStop']['aTimeR'],
                     $date, $stop['stbStop']['aTimeS'], $date);
             } else {
@@ -342,7 +342,7 @@ class liveboard
                 if (key_exists('dPlatfR', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['dPlatfR'];
                     $isPlatformNormal = false;
-                } elseif (key_exists('dPlatfS', $stop['stbStop'])) {
+                } else if (key_exists('dPlatfS', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['dPlatfS'];
                     $isPlatformNormal = true;
                 } else {
@@ -358,7 +358,7 @@ class liveboard
                 if (key_exists('aPlatfR', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['aPlatfR'];
                     $isPlatformNormal = false;
-                } elseif (key_exists('aPlatfS', $stop['stbStop'])) {
+                } else if (key_exists('aPlatfS', $stop['stbStop'])) {
                     $platform = $stop['stbStop']['aPlatfS'];
                     $isPlatformNormal = true;
                 } else {
@@ -391,7 +391,7 @@ class liveboard
                 if (key_exists('dCncl', $stop['stbStop'])) {
                     $stopCanceled = $stop['stbStop']['dCncl'];
                 }
-            } elseif (key_exists('aProgType', $stop['stbStop'])) {
+            } else if (key_exists('aProgType', $stop['stbStop'])) {
                 if ($stop['stbStop']['aProgType'] == 'REPORTED') {
                     $left = 1;
                 }

--- a/api/data/NMBS/stations.php
+++ b/api/data/NMBS/stations.php
@@ -117,14 +117,14 @@ class stations
             if (strlen($stationitem->name) === strlen($name)) {
                 $station = $stationitem;
                 break;
-            } else if (isset($stationitem->alternative) && is_array($stationitem->alternative)) {
+            } elseif (isset($stationitem->alternative) && is_array($stationitem->alternative)) {
                 foreach ($stationitem->alternative as $alt) {
                     if (strlen($alt->{'@value'}) === strlen($name)) {
                         $station = $stationitem;
                         break;
                     }
                 }
-            } else if (isset($stationitem->alternative) && strlen($stationitem->alternative->{'@value'}) === strlen($name)) {
+            } elseif (isset($stationitem->alternative) && strlen($stationitem->alternative->{'@value'}) === strlen($name)) {
                 $station = $stationitem;
                 break;
             }

--- a/api/data/NMBS/stations.php
+++ b/api/data/NMBS/stations.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2011 by iRail vzw/asbl
  * Copyright (C) 2015 by Open Knowledge Belgium vzw/asbl.
@@ -27,10 +28,18 @@ class stations
     {
         $station = new Station();
         $id = str_replace('http://irail.be/stations/NMBS/', '', $newstation->{'@id'});
-        $station->id = 'BE.NMBS.'.$id; //old-style iRail ids
+        $station->id = 'BE.NMBS.' . $id; //old-style iRail ids
+        $station->hafasId = $id;
         $station->locationX = $newstation->longitude;
         $station->locationY = $newstation->latitude;
         $station->{'@id'} = $newstation->{'@id'};
+
+        if ($newstation->country == "http://sws.geonames.org/2802361/") {
+            $station->country = "BE";
+        } else {
+            $station->country = "Unknown";
+        }
+
         if (isset($newstation->{'alternative'})) {
             foreach ($newstation->{'alternative'} as $alternatives) {
                 if ($alternatives->{'@language'} == strtolower($lang)) {
@@ -40,11 +49,9 @@ class stations
         }
         $station->standardname = $newstation->name;
 
-        if (! isset($station->name)) {
+        if (!isset($station->name)) {
             $station->name = $station->standardname;
         }
-        $station->setHID($id);
-
         return $station;
     }
 
@@ -61,7 +68,7 @@ class stations
         return $station;
     }
 
-    
+
     /**
      * @param $id
      * @param $lang
@@ -92,7 +99,7 @@ class stations
         if (substr($name, 0, 1) == '0' || substr($name, 0, 7) == 'BE.NMBS' || substr($name, 0, 7) == 'http://') {
             return self::getStationFromID($name, $lang);
         }
-        
+
         $name = html_entity_decode($name, ENT_COMPAT | ENT_HTML401, 'UTF-8');
         $name = preg_replace("/[ ]?\([a-zA-Z]+\)/", '', $name);
         $name = str_replace(' [NMBS/SNCB]', '', $name);
@@ -100,8 +107,8 @@ class stations
         $name = explode('/', $name);
         $name = trim($name[0]);
         $stationsgraph = irail\stations\Stations::getStations($name);
-        if (! isset($stationsgraph->{'@graph'}[0])) {
-            throw new Exception('Could not match \''.$name.'\' with a station id in iRail. Please report this issue at https://github.com/irail/stations/issues/new if you think we should support your query.');
+        if (!isset($stationsgraph->{'@graph'}[0])) {
+            throw new Exception('Could not match \'' . $name . '\' with a station id in iRail. Please report this issue at https://github.com/irail/stations/issues/new if you think we should support your query.');
         }
         $station = $stationsgraph->{'@graph'}[0];
 
@@ -110,14 +117,14 @@ class stations
             if (strlen($stationitem->name) === strlen($name)) {
                 $station = $stationitem;
                 break;
-            } elseif (isset($stationitem->alternative) && is_array($stationitem->alternative)) {
+            } else if (isset($stationitem->alternative) && is_array($stationitem->alternative)) {
                 foreach ($stationitem->alternative as $alt) {
                     if (strlen($alt->{'@value'}) === strlen($name)) {
                         $station = $stationitem;
                         break;
                     }
                 }
-            } elseif (isset($stationitem->alternative) && strlen($stationitem->alternative->{'@value'}) === strlen($name)) {
+            } else if (isset($stationitem->alternative) && strlen($stationitem->alternative->{'@value'}) === strlen($name)) {
                 $station = $stationitem;
                 break;
             }
@@ -140,4 +147,6 @@ class stations
 
         return $stations;
     }
-};
+}
+
+;

--- a/api/data/structs.php
+++ b/api/data/structs.php
@@ -21,17 +21,12 @@ class Connection
 
 class Station
 {
-    private $hafasid;
+    public $hafasId;
+    public $country;
+    public $locationX;
+    public $locationY;
+    public $id;
 
-    public function setHID($id)
-    {
-        $this->hafasid = $id;
-    }
-
-    public function getHID()
-    {
-        return $this->hafasid;
-    }
 }
 
 class DepartureArrival

--- a/api/data/structs.php
+++ b/api/data/structs.php
@@ -26,7 +26,6 @@ class Station
     public $locationX;
     public $locationY;
     public $id;
-
 }
 
 class DepartureArrival

--- a/api/requests/ConnectionsRequest.php
+++ b/api/requests/ConnectionsRequest.php
@@ -30,7 +30,7 @@ class ConnectionsRequest extends Request
         parent::setGetVar('date', date('dmy'));
         parent::setGetVar('time', date('Hi'));
         parent::setGetVar('timeSel', 'depart');
-        parent::setGetVar('typeOfTransport', 'train');
+        parent::setGetVar('typeOfTransport', 'automatic');
         parent::setGetVar('fast', 'false');
         parent::setGetVar('alerts', 'false');
         parent::processRequiredVars(['from', 'to']);


### PR DESCRIPTION
This PR implements the method discussed in #356 to automaticly determine whether or not to include high-speed trains.
When both stations are in Belgium, high speed trains are excluded unless the query explicitly states to include all traffic. This is needed as our data source will hide local trains due to faster high speed trains when searching for routes, while those high-speed trains are useless to most of the travellers