### PR TITLE
Escape quotes when serializing JSON

### DIFF
--- a/api/output/Json.php
+++ b/api/output/Json.php
@@ -112,6 +112,7 @@ class Json extends Printer
      */
     public function startKeyVal($key, $val)
     {
+        $val = str_replace('"','\"',$val);
         echo "\"$key\":\"$val\"";
     }
 


### PR DESCRIPTION
Fixes #368 , validated in staging