### PR TITLE
Include intermediary stops #348

### DIFF
--- a/api/data/NMBS/Composition.php
+++ b/api/data/NMBS/Composition.php
@@ -207,5 +207,4 @@ class Composition
     {
         return 'NMBSComposition|' . $id;
     }
-
 }

--- a/api/data/NMBS/Connections.php
+++ b/api/data/NMBS/Connections.php
@@ -66,8 +66,8 @@ class Connections
         string $time,
         string $date,
         string $lang,
-        string $timeSel = 'depart',
-        string $typeOfTransport = self::TYPE_TRANSPORT_KEY_AUTOMATIC,
+        string $timeSel,
+        string $typeOfTransport,
         ConnectionsRequest $request
     ) {
         // TODO: clean the whole station name/id to object flow
@@ -591,8 +591,7 @@ class Connections
 
 
         $connection->departure->vehicle = $trainsInConnection[0]->vehicle;
-        // TODO: evaluate if we want to include the intermediate stops, and if so, where
-        //$connection->departure->nextIntermediateStop = $trains[0]->stops;
+        $connection->departure->stop = $trainsInConnection[0]->stops;
 
         $connection->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($departureStation->{'@id'}),
                 2) . '/' . date('Ymd', $connection->departure->time) . '/' . substr($trainsInConnection[0]->vehicle,
@@ -1009,8 +1008,7 @@ class Connections
         $constructedVia->arrival->vehicle = $trains[$viaIndex]->vehicle;
         $constructedVia->departure->vehicle = $trains[$viaIndex + 1]->vehicle;
 
-        // TODO: evaluate if we want to include the intermediate stops, and if so, where
-        //$constructedVia->nextIntermediateStop = $trains[$viaIndex + 1]->stops;
+        $constructedVia->stop = $trains[$viaIndex + 1]->stops;
         $constructedVia->station = $trains[$viaIndex]->arrival->station;
 
         $constructedVia->departure->departureConnection = Tools::createDepartureUri($constructedVia->station,

--- a/api/data/NMBS/Connections.php
+++ b/api/data/NMBS/Connections.php
@@ -738,7 +738,7 @@ class Connections
         $arrivalTime = Tools::transformTime($trainRide['arr']['aTimeS'],
             $hafasConnection['date']);
 
-       $arrivalPlatform = self::parseArrivalPlatform($trainRide['arr']);
+        $arrivalPlatform = self::parseArrivalPlatform($trainRide['arr']);
 
 
         if (key_exists('aTimeR', $trainRide['arr'])) {

--- a/api/data/structs.php
+++ b/api/data/structs.php
@@ -21,9 +21,8 @@ class Connection
     public $arrival;
 
     public $via;
- // not compulsory
+    // not compulsory
     public $duration;
-
 }
 
 class Station
@@ -37,7 +36,6 @@ class Station
     public $id;
 
     public $name;
-
 }
 
 class DepartureArrival
@@ -53,7 +51,6 @@ class DepartureArrival
     public $platform;
 
     public $canceled;
-
 }
 
 class Platform
@@ -73,7 +70,6 @@ class Platform
         $this->name = $name;
 
         $this->normal = $normal;
-
     }
 }
 
@@ -88,7 +84,6 @@ class Via
     public $station;
 
     public $vehicle;
-
 }
 
 class Vehicle
@@ -100,7 +95,6 @@ class Vehicle
     public $name;
 
     public $shortname;
-
 }
 
 class ViaDepartureArrival
@@ -110,7 +104,6 @@ class ViaDepartureArrival
     public $platform;
 
     public $isExtraStop;
-
 }
 
 class Stop
@@ -124,7 +117,6 @@ class Stop
     public $platform;
 
     public $canceled;
-
 }
 
 class Alert
@@ -132,7 +124,6 @@ class Alert
     public $header;
 
     public $description;
-
 }
 
 class TrainCompositionResult
@@ -141,7 +132,6 @@ class TrainCompositionResult
      * @var $segment TrainCompositionInSegment[] A list of all segments with their own composition for this train ride.
      */
     public $segment;
-
 }
 
 
@@ -156,7 +146,6 @@ class TrainCompositionInSegment
      * @var $composition TrainComposition.
      */
     public $composition;
-
 }
 
 class TrainComposition
@@ -171,7 +160,6 @@ class TrainComposition
      * @var TrainCompositionUnit[] the units in this composition.
      */
     public $unit;
-
 }
 
 class TrainCompositionUnit
@@ -288,7 +276,8 @@ class TrainCompositionUnit
     //-- Other types can be included dynamically but aren't guaranteed to be present
 }
 
-class RollingMaterialType {
+class RollingMaterialType
+{
     /**
      * @var $parent_type string the parent type, such as I6, M5, HLE27, AM86 ...
      */


### PR DESCRIPTION
This PR will add intermediary stops to journey queries. This way travellers can see how many stops their train will make before they have to get off.