### PR TITLE
Add type field to disturbances

### DIFF
--- a/api/data/NMBS/Disturbances.php
+++ b/api/data/NMBS/Disturbances.php
@@ -4,6 +4,10 @@ require_once __DIR__ . '/Tools.php';
 
 class Disturbances
 {
+
+    const TYPE_DISTURBANCE = 'disturbance';
+    const TYPE_PLANNED = 'planned';
+
     /**
      * This is the entry point for the data fetching and transformation.
      * @param DataRoot $dataroot
@@ -42,6 +46,7 @@ class Disturbances
             $disturbance->title = "Website issues";
             $disturbance->description = "It seems there are problems with the NMBS/SNCB website. Routeplanning or live data might not be available.";
             $disturbance->link = "https://belgianrail.be/";
+            $disturbance->type = self::TYPE_DISTURBANCE;
             $disturbance->timestamp = round(microtime(true));
             array_unshift($data, $disturbance);
         }
@@ -161,6 +166,11 @@ class Disturbances
 
             $pubdate = $item->pubDate;
             $disturbance->timestamp = strtotime($pubdate);
+
+            $disturbance->type = self::TYPE_DISTURBANCE;
+            if (strpos($disturbance->link, 'tplParamHimMsgInfoGroup=works') !== false) {
+                $disturbance->type = self::TYPE_PLANNED;
+            }
 
             $disturbances[] = $disturbance;
         }

--- a/api/data/NMBS/Disturbances.php
+++ b/api/data/NMBS/Disturbances.php
@@ -128,7 +128,7 @@ class Disturbances
 
         // Loop through all news items.
         foreach ($data->channel->item as $item) {
-            $disturbance = new stdClass();
+            $disturbance = new Disturbance();
 
             // Each string has to be converted to force parsing the CDATA. Also trim any leading or trailing newlines.
             $disturbance->title = trim((String)$item->title, "\r\n ");

--- a/api/data/NMBS/Disturbances.php
+++ b/api/data/NMBS/Disturbances.php
@@ -4,7 +4,6 @@ require_once __DIR__ . '/Tools.php';
 
 class Disturbances
 {
-
     const TYPE_DISTURBANCE = 'disturbance';
     const TYPE_PLANNED = 'planned';
 

--- a/api/data/structs.php
+++ b/api/data/structs.php
@@ -1,6 +1,6 @@
 <?php
 /** Copyright (C) 2011 by iRail vzw/asbl
- * This is the Connection class. It contains data.
+ * This file contains classes used in API responses.
  *
  * @author pieterc
  */
@@ -13,6 +13,16 @@
 //public $arrival;
 
 // }
+
+class Disturbance
+{
+    public $title;
+    public $description;
+    // public $attachment; // Not compulsory, commented to ensure null values don't cause issues in the printer
+    public $link; // Not compulsory
+    public $type;
+    public $timestamp;
+}
 
 class Connection
 {


### PR DESCRIPTION
When merged, this PR will add a "type" field to all disturbance objects on the /disturbances page. Possible values are 'disturbance' and 'planned'. This way scheduled work can be distinguished from unscheduled disturbances.

Fixes #393 