### PR TITLE
Ensure the arrived/left data for intermediate stops is sane

### DIFF
--- a/api/data/NMBS/Connections.php
+++ b/api/data/NMBS/Connections.php
@@ -822,6 +822,15 @@ class Connections
                     $rawIntermediateStop, $hafasConnection);
             }
 
+            // Sanity check: ensure that the arrived/left status for intermediate stops is correct.
+            // If a train has reached the next intermediate stop, it must have passed the previous one.
+            for ($i = count($parsedTrain->stops) - 2; $i >= 0; $i--) {
+                if ($parsedTrain->stops[$i + 1]->arrived) {
+                    $parsedTrain->stops[$i]->left = 1;
+                    $parsedTrain->stops[$i]->arrived = 1;
+                }
+            }
+
             $parsedTrain->alerts = [];
             try {
                 if (key_exists('himL', $trainRide['jny']) && is_array($trainRide['jny']['himL'])) {


### PR DESCRIPTION
This PR improves data quality for intermediate stops data (#348). This PR ensures that both left and arrived for an intermediate stop are set to 1 (true) if the train has arrived in a later stop.

A train A->B->C which is reported as expected in A and B, but arrived in C, will be fixed to show as arrived and departed in both A and B.