### PR TITLE
Ensure the arrived/left data for intermediate stops is sane #348

### DIFF
--- a/api/APICall.php
+++ b/api/APICall.php
@@ -127,12 +127,18 @@ class APICall
                 $query['departureStop'] = $this->request->getFrom();
                 $query['arrivalStop'] = $this->request->getTo();
                 //transform to ISO8601
-                $query['dateTime'] = preg_replace('/(\d\d\d\d)(\d\d)(\d\d)/i', '$1-$2-$3',
-                        $this->request->getDate()) . 'T' . $this->request->getTime() . ':00' . '+01:00';
+                $query['dateTime'] = preg_replace(
+                    '/(\d\d\d\d)(\d\d)(\d\d)/i',
+                    '$1-$2-$3',
+                    $this->request->getDate()
+                ) . 'T' . $this->request->getTime() . ':00' . '+01:00';
                 $query['journeyoptions'] = $this->request->getJourneyOptions();
             } elseif ($this->resourcename === 'liveboard') {
-                $query['dateTime'] = preg_replace('/(\d\d\d\d)(\d\d)(\d\d)/i', '$1-$2-$3',
-                        $this->request->getDate()) . 'T' . $this->request->getTime() . ':00' . '+01:00';
+                $query['dateTime'] = preg_replace(
+                    '/(\d\d\d\d)(\d\d)(\d\d)/i',
+                    '$1-$2-$3',
+                    $this->request->getDate()
+                ) . 'T' . $this->request->getTime() . ':00' . '+01:00';
                 $query['departureStop'] = $this->request->getStation();
             } elseif ($this->resourcename === 'VehicleInformation') {
                 $query['vehicle'] = $this->request->getVehicleId();

--- a/api/APIPost.php
+++ b/api/APIPost.php
@@ -79,16 +79,20 @@ class APIPost
         if (!is_null($this->postData->connection) && !is_null($this->postData->from) && !is_null($this->postData->date) && !is_null($this->postData->vehicle) && !is_null($this->postData->occupancy)) {
             if (OccupancyOperations::isCorrectPostURI($this->postData->occupancy)) {
                 try {
-                    if (!in_array($this->postData->occupancy,
-                        [OccupancyOperations::LOW, OccupancyOperations::MEDIUM, OccupancyOperations::HIGH])
+                    if (!in_array(
+                        $this->postData->occupancy,
+                        [OccupancyOperations::LOW, OccupancyOperations::MEDIUM, OccupancyOperations::HIGH]
+                    )
                     ) {
                         header('HTTP/1.1 400 Invalid Request');
                         die();
                     }
 
                     // validate connection ids.
-                    if (preg_match("/^http:\/\/irail\.be\/connections\/\d{7}\/\d{8}\/.{4,7}$/",
-                            $this->postData->connection) === 0
+                    if (preg_match(
+                        "/^http:\/\/irail\.be\/connections\/\d{7}\/\d{8}\/.{4,7}$/",
+                        $this->postData->connection
+                    ) === 0
                     ) {
                         header('HTTP/1.1 400 Invalid Connection ID');
                         die();
@@ -155,12 +159,16 @@ class APIPost
                     $this->buildError($e);
                 }
             } else {
-                throw new Exception('Make sure that the occupancy parameter is one of these URIs: https://api.irail.be/terms/low, https://api.irail.be/terms/medium or https://api.irail.be/terms/high',
-                    400);
+                throw new Exception(
+                    'Make sure that the occupancy parameter is one of these URIs: https://api.irail.be/terms/low, https://api.irail.be/terms/medium or https://api.irail.be/terms/high',
+                    400
+                );
             }
         } else {
-            throw new Exception('Incorrect post parameters, the occupancy post request must contain the following parameters: connection, from, date, vehicle and occupancy (optionally "to" can be given as a parameter).',
-                400);
+            throw new Exception(
+                'Incorrect post parameters, the occupancy post request must contain the following parameters: connection, from, date, vehicle and occupancy (optionally "to" can be given as a parameter).',
+                400
+            );
         }
     }
 

--- a/api/data/DataRoot.php
+++ b/api/data/DataRoot.php
@@ -77,8 +77,10 @@ class DataRoot
             } elseif ($e->getCode() == '300') {
                 throw new Exception($e->getMessage(), 300);
             } else {
-                throw new Exception('Could not get data: ' . $e->getMessage() . '. Please report this issue at https://github.com/irail/irail/issues/new',
-                    $e->getCode());
+                throw new Exception(
+                    'Could not get data: ' . $e->getMessage() . '. Please report this issue at https://github.com/irail/irail/issues/new',
+                    $e->getCode()
+                );
             }
         }
     }

--- a/api/data/NMBS/Composition.php
+++ b/api/data/NMBS/Composition.php
@@ -13,8 +13,11 @@ class Composition
 {
     public static function fillDataRoot($dataroot, CompositionRequest $request)
     {
-        $dataroot->composition = self::scrapeComposition($request->getId(), $request->getLang(),
-            $request->getShouldReturnRawData());
+        $dataroot->composition = self::scrapeComposition(
+            $request->getId(),
+            $request->getLang(),
+            $request->getShouldReturnRawData()
+        );
     }
 
     /**
@@ -61,8 +64,11 @@ class Composition
         // Build a result
         $result = new TrainCompositionResult;
         foreach ($data as $travelsegmentWithCompositionData) {
-            $result->segment[] = self::parseOneSegmentWithCompositionData($travelsegmentWithCompositionData, $language,
-                $returnAllData);
+            $result->segment[] = self::parseOneSegmentWithCompositionData(
+                $travelsegmentWithCompositionData,
+                $language,
+                $returnAllData
+            );
         }
 
         return $result;
@@ -71,10 +77,14 @@ class Composition
     private static function parseOneSegmentWithCompositionData($travelsegmentWithCompositionData, string $language, bool $returnAllData): TrainCompositionInSegment
     {
         $result = new TrainCompositionInSegment;
-        $result->origin = stations::getStationFromID('00' . $travelsegmentWithCompositionData->ptCarFrom->uicCode,
-            $language);
-        $result->destination = stations::getStationFromID('00' . $travelsegmentWithCompositionData->ptCarTo->uicCode,
-            $language);
+        $result->origin = stations::getStationFromID(
+            '00' . $travelsegmentWithCompositionData->ptCarFrom->uicCode,
+            $language
+        );
+        $result->destination = stations::getStationFromID(
+            '00' . $travelsegmentWithCompositionData->ptCarTo->uicCode,
+            $language
+        );
         $result->composition = self::parseCompositionData($travelsegmentWithCompositionData, $returnAllData);
 
         // Set the left/right orientation on carriages. This can only be done by evaluating all carriages at the same time
@@ -209,8 +219,10 @@ class Composition
 
         // Store the raw output to a file on disk, for debug purposes
         if (key_exists('debug', $_GET) && isset($_GET['debug'])) {
-            file_put_contents('../storage/debug-composition-' . $vehicleId . '-' . $language . '-' . time() . '.log',
-                $response);
+            file_put_contents(
+                '../storage/debug-composition-' . $vehicleId . '-' . $language . '-' . time() . '.log',
+                $response
+            );
         }
 
         return json_decode($response);

--- a/api/data/NMBS/Connections.php
+++ b/api/data/NMBS/Connections.php
@@ -44,9 +44,16 @@ class Connections
             $to = Stations::getStationFromID($request->getTo(), $request->getLang());
             $to = $to->name;
         }
-        $dataroot->connection = self::scrapeConnections($from, $to, $request->getTime(), $request->getDate(),
-            $request->getLang(), $request->getTimeSel(),
-            $request->getTypeOfTransport(), $request);
+        $dataroot->connection = self::scrapeConnections(
+            $from,
+            $to,
+            $request->getTime(),
+            $request->getDate(),
+            $request->getLang(),
+            $request->getTimeSel(),
+            $request->getTypeOfTransport(),
+            $request
+        );
     }
 
     /**
@@ -74,8 +81,15 @@ class Connections
         // TODO: clean the whole station name/id to object flow
         $stations = self::getStationsFromName($from, $to, $lang, $request);
 
-        $nmbsCacheKey = self::getNmbsCacheKey($stations[0]->_hafasId, $stations[1]->_hafasId, $lang, $time, $date,
-            $timeSel, $typeOfTransport);
+        $nmbsCacheKey = self::getNmbsCacheKey(
+            $stations[0]->_hafasId,
+            $stations[1]->_hafasId,
+            $lang,
+            $time,
+            $date,
+            $timeSel,
+            $typeOfTransport
+        );
 
         $xml = Tools::getCachedObject($nmbsCacheKey);
         if ($xml === false) {
@@ -196,8 +210,15 @@ class Connections
             $timeSel = 1;
         }
 
-        $postdata = self::createNmbsPayload($stationFrom, $stationTo, $lang, $time, $date, $timeSel,
-            $typeOfTransportCode);
+        $postdata = self::createNmbsPayload(
+            $stationFrom,
+            $stationTo,
+            $lang,
+            $time,
+            $date,
+            $timeSel,
+            $typeOfTransportCode
+        );
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
@@ -212,8 +233,10 @@ class Connections
 
         // Store the raw output to a file on disk, for debug purposes
         if (key_exists('debug', $_GET) && isset($_GET['debug'])) {
-            file_put_contents('../storage/debug-connections-' . $stationFrom->_hafasId . '-' . $stationTo->_hafasId . '-' . time() . '.log',
-                $response);
+            file_put_contents(
+                '../storage/debug-connections-' . $stationFrom->_hafasId . '-' . $stationTo->_hafasId . '-' . time() . '.log',
+                $response
+            );
         }
 
         curl_close($ch);
@@ -384,8 +407,15 @@ class Connections
 
         $connections = [];
         foreach ($json['svcResL'][0]['res']['outConL'] as $conn) {
-            $connections[] = self::parseHafasConnection($request, $conn, $locationDefinitions, $vehicleDefinitions,
-                $alertDefinitions, $remarkDefinitions, $lang);
+            $connections[] = self::parseHafasConnection(
+                $request,
+                $conn,
+                $locationDefinitions,
+                $vehicleDefinitions,
+                $alertDefinitions,
+                $remarkDefinitions,
+                $lang
+            );
         }
 
         return $connections;
@@ -438,8 +468,11 @@ class Connections
         foreach ($json['svcResL'][0]['res']['common']['remL'] as $rawRemark) {
             $remark = new StdClass();
             $remark->code = $rawRemark['code'];
-            $remark->description = strip_tags(preg_replace("/<a href=\".*?\">.*?<\/a>/", '',
-                $rawRemark['txtN']));
+            $remark->description = strip_tags(preg_replace(
+                "/<a href=\".*?\">.*?<\/a>/",
+                '',
+                $rawRemark['txtN']
+            ));
 
             $matches = [];
             preg_match_all("/<a href=\"(.*?)\">.*?<\/a>/", urldecode($rawRemark['txtN']), $matches);
@@ -473,10 +506,14 @@ class Connections
             }
 
             if (key_exists('pubChL', $rawAlert)) {
-                $alert->startTime = Tools::transformTime($rawAlert['pubChL'][0]['fTime'],
-                    $rawAlert['pubChL'][0]['fDate']);
-                $alert->endTime = Tools::transformTime($rawAlert['pubChL'][0]['tTime'],
-                    $rawAlert['pubChL'][0]['tDate']);
+                $alert->startTime = Tools::transformTime(
+                    $rawAlert['pubChL'][0]['fTime'],
+                    $rawAlert['pubChL'][0]['fDate']
+                );
+                $alert->endTime = Tools::transformTime(
+                    $rawAlert['pubChL'][0]['tTime'],
+                    $rawAlert['pubChL'][0]['tDate']
+                );
             }
 
             $alertDefinitions[] = $alert;
@@ -518,13 +555,19 @@ class Connections
 
 
         if (key_exists('dTimeR', $hafasConnection['dep'])) {
-            $connection->departure->delay = Tools::calculateSecondsHHMMSS($hafasConnection['dep']['dTimeR'],
-                $hafasConnection['date'], $hafasConnection['dep']['dTimeS'], $hafasConnection['date']);
+            $connection->departure->delay = Tools::calculateSecondsHHMMSS(
+                $hafasConnection['dep']['dTimeR'],
+                $hafasConnection['date'],
+                $hafasConnection['dep']['dTimeS'],
+                $hafasConnection['date']
+            );
         } else {
             $connection->departure->delay = 0;
         }
-        $connection->departure->time = Tools::transformTime($hafasConnection['dep']['dTimeS'],
-            $hafasConnection['date']);
+        $connection->departure->time = Tools::transformTime(
+            $hafasConnection['dep']['dTimeS'],
+            $hafasConnection['date']
+        );
 
         $connection->departure->platform = self::parseDeparturePlatform($hafasConnection['dep']);
 
@@ -532,8 +575,12 @@ class Connections
         $connection->arrival->station = $arrivalStation;
 
         if (key_exists('aTimeR', $hafasConnection['arr'])) {
-            $connection->arrival->delay = Tools::calculateSecondsHHMMSS($hafasConnection['arr']['aTimeR'],
-                $hafasConnection['date'], $hafasConnection['arr']['aTimeS'], $hafasConnection['date']);
+            $connection->arrival->delay = Tools::calculateSecondsHHMMSS(
+                $hafasConnection['arr']['aTimeR'],
+                $hafasConnection['date'],
+                $hafasConnection['arr']['aTimeS'],
+                $hafasConnection['date']
+            );
         } else {
             $connection->arrival->delay = 0;
         }
@@ -542,8 +589,13 @@ class Connections
 
         $connection->arrival->platform = self::parseArrivalPlatform($arrival = $hafasConnection['arr']);
 
-        $trainsInConnection = self::parseHafasTrainsForConnection($hafasConnection, $locationDefinitions,
-            $vehicleDefinitions, $alertDefinitions, $lang);
+        $trainsInConnection = self::parseHafasTrainsForConnection(
+            $hafasConnection,
+            $locationDefinitions,
+            $vehicleDefinitions,
+            $alertDefinitions,
+            $lang
+        );
 
         $connection->departure->canceled = $trainsInConnection[0]->departure->canceled;
         $connection->arrival->canceled = end($trainsInConnection)->arrival->canceled;
@@ -597,9 +649,13 @@ class Connections
         array_pop($connection->departure->stop);
 
 
-        $connection->departure->departureConnection = 'http://irail.be/connections/' . substr(basename($departureStation->{'@id'}),
-                2) . '/' . date('Ymd', $connection->departure->time) . '/' . substr($trainsInConnection[0]->vehicle,
-                strrpos($trainsInConnection[0]->vehicle, '.') + 1);
+        $connection->departure->departureConnection = 'http://irail.be/connections/' . substr(
+            basename($departureStation->{'@id'}),
+            2
+        ) . '/' . date('Ymd', $connection->departure->time) . '/' . substr(
+                    $trainsInConnection[0]->vehicle,
+                    strrpos($trainsInConnection[0]->vehicle, '.') + 1
+                );
 
         $connection->departure->direction = $trainsInConnection[0]->direction;
         $connection->departure->left = $trainsInConnection[0]->left;
@@ -700,8 +756,14 @@ class Connections
                 continue;
             }
 
-            $trainsInConnection[] = self::parseHafasTrain($trainRide, $hafasConnection, $locationDefinitions,
-                $vehicleDefinitions, $alertDefinitions, $lang);
+            $trainsInConnection[] = self::parseHafasTrain(
+                $trainRide,
+                $hafasConnection,
+                $locationDefinitions,
+                $vehicleDefinitions,
+                $alertDefinitions,
+                $lang
+            );
         }
         return $trainsInConnection;
     }
@@ -728,8 +790,12 @@ class Connections
         $departPlatform = self::parseDeparturePlatform($trainRide['dep']);
 
         if (key_exists('dTimeR', $trainRide['dep'])) {
-            $departDelay = Tools::calculateSecondsHHMMSS($trainRide['dep']['dTimeR'],
-                $hafasConnection['date'], $trainRide['dep']['dTimeS'], $hafasConnection['date']);
+            $departDelay = Tools::calculateSecondsHHMMSS(
+                $trainRide['dep']['dTimeR'],
+                $hafasConnection['date'],
+                $trainRide['dep']['dTimeS'],
+                $hafasConnection['date']
+            );
         } else {
             $departDelay = 0;
         }
@@ -738,15 +804,21 @@ class Connections
             $departDelay = 0;
         }
 
-        $arrivalTime = Tools::transformTime($trainRide['arr']['aTimeS'],
-            $hafasConnection['date']);
+        $arrivalTime = Tools::transformTime(
+            $trainRide['arr']['aTimeS'],
+            $hafasConnection['date']
+        );
 
         $arrivalPlatform = self::parseArrivalPlatform($trainRide['arr']);
 
 
         if (key_exists('aTimeR', $trainRide['arr'])) {
-            $arrivalDelay = Tools::calculateSecondsHHMMSS($trainRide['arr']['aTimeR'],
-                $hafasConnection['date'], $trainRide['arr']['aTimeS'], $hafasConnection['date']);
+            $arrivalDelay = Tools::calculateSecondsHHMMSS(
+                $trainRide['arr']['aTimeR'],
+                $hafasConnection['date'],
+                $trainRide['arr']['aTimeS'],
+                $hafasConnection['date']
+            );
         } else {
             $arrivalDelay = 0;
         }
@@ -792,8 +864,12 @@ class Connections
 
         $departTime = Tools::transformTime($trainRide['dep']['dTimeS'], $hafasConnection['date']);
 
-        $parsedTrain->duration = Tools::calculateSecondsHHMMSS($arrivalTime, $hafasConnection['date'],
-            $departTime, $hafasConnection['date']);
+        $parsedTrain->duration = Tools::calculateSecondsHHMMSS(
+            $arrivalTime,
+            $hafasConnection['date'],
+            $departTime,
+            $hafasConnection['date']
+        );
 
         if (self::hasConnectionTrainDepartureBeenReported($trainRide)) {
             $parsedTrain->left = 1;
@@ -809,10 +885,14 @@ class Connections
             $parsedTrain->arrived = 0;
         }
 
-        $parsedTrain->departure->station = Stations::getStationFromID($locationDefinitions[$trainRide['dep']['locX']]->id,
-            $lang);
-        $parsedTrain->arrival->station = Stations::getStationFromID($locationDefinitions[$trainRide['arr']['locX']]->id,
-            $lang);
+        $parsedTrain->departure->station = Stations::getStationFromID(
+            $locationDefinitions[$trainRide['dep']['locX']]->id,
+            $lang
+        );
+        $parsedTrain->arrival->station = Stations::getStationFromID(
+            $locationDefinitions[$trainRide['arr']['locX']]->id,
+            $lang
+        );
 
         $parsedTrain->isPartiallyCancelled = false;
         $parsedTrain->stops = [];
@@ -822,11 +902,15 @@ class Connections
             }
 
             foreach ($trainRide['jny']['stopL'] as $rawIntermediateStop) {
-                $intermediateStop = self::parseHafasIntermediateStop($lang, $locationDefinitions,
+                $intermediateStop = self::parseHafasIntermediateStop(
+                    $lang,
+                    $locationDefinitions,
                     $vehicleDefinitions,
-                    $rawIntermediateStop, $hafasConnection);
+                    $rawIntermediateStop,
+                    $hafasConnection
+                );
                 $parsedTrain->stops[] = $intermediateStop;
-                if ($intermediateStop->left == 1 || $intermediateStop->arrived == 1 ){
+                if ($intermediateStop->left == 1 || $intermediateStop->arrived == 1) {
                     $parsedTrain->left = 1; // If the train has left from an intermediate stop, it has automatically left from its first stop!
                 }
             }
@@ -900,12 +984,16 @@ class Connections
                                   "isImp": true
                                         */
         $intermediateStop = new StdClass();
-        $intermediateStop->station = Stations::getStationFromID($locationDefinitions[$rawIntermediateStop['locX']]->id,
-            $lang);
+        $intermediateStop->station = Stations::getStationFromID(
+            $locationDefinitions[$rawIntermediateStop['locX']]->id,
+            $lang
+        );
 
         if (key_exists('aTimeS', $rawIntermediateStop)) {
-            $intermediateStop->scheduledArrivalTime = Tools::transformTime($rawIntermediateStop['aTimeS'],
-                $conn['date']);
+            $intermediateStop->scheduledArrivalTime = Tools::transformTime(
+                $rawIntermediateStop['aTimeS'],
+                $conn['date']
+            );
         } else {
             $intermediateStop->scheduledArrivalTime = null;
         }
@@ -924,24 +1012,33 @@ class Connections
         }
 
         if (key_exists('aTimeR', $rawIntermediateStop)) {
-            $intermediateStop->arrivalDelay = Tools::calculateSecondsHHMMSS($rawIntermediateStop['aTimeR'],
-                $conn['date'], $rawIntermediateStop['aTimeS'], $conn['date']);
+            $intermediateStop->arrivalDelay = Tools::calculateSecondsHHMMSS(
+                $rawIntermediateStop['aTimeR'],
+                $conn['date'],
+                $rawIntermediateStop['aTimeS'],
+                $conn['date']
+            );
         } else {
             $intermediateStop->arrivalDelay = 0;
         }
 
 
         if (key_exists('dTimeS', $rawIntermediateStop)) {
-            $intermediateStop->scheduledDepartureTime = Tools::transformTime($rawIntermediateStop['dTimeS'],
-                $conn['date']);
+            $intermediateStop->scheduledDepartureTime = Tools::transformTime(
+                $rawIntermediateStop['dTimeS'],
+                $conn['date']
+            );
         } else {
             $intermediateStop->scheduledDepartureTime = null;
         }
 
         if (key_exists('dTimeR', $rawIntermediateStop)) {
-            $intermediateStop->departureDelay = Tools::calculateSecondsHHMMSS($rawIntermediateStop['dTimeR'],
-                $conn['date'], $rawIntermediateStop['dTimeS'],
-                $conn['date']);
+            $intermediateStop->departureDelay = Tools::calculateSecondsHHMMSS(
+                $rawIntermediateStop['dTimeR'],
+                $conn['date'],
+                $rawIntermediateStop['dTimeS'],
+                $conn['date']
+            );
         } else {
             $intermediateStop->departureDelay = 0;
         }
@@ -963,12 +1060,16 @@ class Connections
 
         // Prevent null values in edge cases. If one of both values is unknown, copy the non-null value. In case both
         // are null, hope for the best
-        if (!property_exists($intermediateStop,
-                'scheduledDepartureTime') || $intermediateStop->scheduledDepartureTime == null) {
+        if (!property_exists(
+            $intermediateStop,
+            'scheduledDepartureTime'
+        ) || $intermediateStop->scheduledDepartureTime == null) {
             $intermediateStop->scheduledDepartureTime = $intermediateStop->scheduledArrivalTime;
         }
-        if (!property_exists($intermediateStop,
-                'scheduledArrivalTime') || $intermediateStop->scheduledArrivalTime == null) {
+        if (!property_exists(
+            $intermediateStop,
+            'scheduledArrivalTime'
+        ) || $intermediateStop->scheduledArrivalTime == null) {
             $intermediateStop->scheduledArrivalTime = $intermediateStop->scheduledDepartureTime;
         }
 
@@ -988,9 +1089,13 @@ class Connections
             $intermediateStop->isExtraStop = 0;
         }
 
-        $intermediateStop->departureConnection = 'http://irail.be/connections/' . substr($locationDefinitions[$rawIntermediateStop['locX']]->id,
-                2) . '/' . date('Ymd',
-                $intermediateStop->scheduledDepartureTime) . '/' . $vehicleDefinitions[$rawIntermediateStop['dProdX']]->name;
+        $intermediateStop->departureConnection = 'http://irail.be/connections/' . substr(
+            $locationDefinitions[$rawIntermediateStop['locX']]->id,
+            2
+        ) . '/' . date(
+                    'Ymd',
+                    $intermediateStop->scheduledDepartureTime
+                ) . '/' . $vehicleDefinitions[$rawIntermediateStop['dProdX']]->name;
 
         return $intermediateStop;
     }
@@ -1029,8 +1134,10 @@ class Connections
         $constructedVia->departure->platform = $trains[$viaIndex + 1]->departure->platform;
         $constructedVia->departure->canceled = $trains[$viaIndex + 1]->departure->canceled;
         $constructedVia->departure->isExtraStop = $trains[$viaIndex + 1]->departure->isExtraStop;
-        if (property_exists($trains[$viaIndex + 1],
-                'alerts') && count($trains[$viaIndex + 1]->alerts) > 0) {
+        if (property_exists(
+            $trains[$viaIndex + 1],
+            'alerts'
+        ) && count($trains[$viaIndex + 1]->alerts) > 0) {
             $constructedVia->departure->alert = $trains[$viaIndex + 1]->alerts;
         }
 
@@ -1055,12 +1162,16 @@ class Connections
 
         $constructedVia->station = $trains[$viaIndex]->arrival->station;
 
-        $constructedVia->departure->departureConnection = Tools::createDepartureUri($constructedVia->station,
+        $constructedVia->departure->departureConnection = Tools::createDepartureUri(
+            $constructedVia->station,
             $constructedVia->departure->time,
-            $constructedVia->departure->vehicle);
-        $constructedVia->arrival->departureConnection = Tools::createDepartureUri($constructedVia->station,
+            $constructedVia->departure->vehicle
+        );
+        $constructedVia->arrival->departureConnection = Tools::createDepartureUri(
+            $constructedVia->station,
             $constructedVia->arrival->time,
-            $constructedVia->arrival->vehicle);
+            $constructedVia->arrival->vehicle
+        );
 
         $vias[$viaIndex] = $constructedVia;
         return $vias;
@@ -1134,11 +1245,15 @@ class Connections
                     if (isset($occupancyConnections[$i]->via)) {
                         foreach ($occupancyConnections[$i]->via as $key => $via) {
                             if ($key < count($occupancyConnections[$i]->via) - 1) {
-                                $vehicleURI = 'http://irail.be/vehicle/' . substr(strrchr($occupancyConnections[$i]->via[$key + 1]->vehicle,
-                                        "."), 1);
+                                $vehicleURI = 'http://irail.be/vehicle/' . substr(strrchr(
+                                    $occupancyConnections[$i]->via[$key + 1]->vehicle,
+                                    "."
+                                ), 1);
                             } else {
-                                $vehicleURI = 'http://irail.be/vehicle/' . substr(strrchr($occupancyConnections[$i]->arrival->vehicle,
-                                        "."), 1);
+                                $vehicleURI = 'http://irail.be/vehicle/' . substr(strrchr(
+                                    $occupancyConnections[$i]->arrival->vehicle,
+                                    "."
+                                ), 1);
                             }
 
                             $from = $via->station->{'@id'};

--- a/api/data/NMBS/Connections.php
+++ b/api/data/NMBS/Connections.php
@@ -822,9 +822,13 @@ class Connections
             }
 
             foreach ($trainRide['jny']['stopL'] as $rawIntermediateStop) {
-                $parsedTrain->stops[] = self::parseHafasIntermediateStop($lang, $locationDefinitions,
+                $intermediateStop = self::parseHafasIntermediateStop($lang, $locationDefinitions,
                     $vehicleDefinitions,
                     $rawIntermediateStop, $hafasConnection);
+                $parsedTrain->stops[] = $intermediateStop;
+                if ($intermediateStop->left == 1 || $intermediateStop->arrived == 1 ){
+                    $parsedTrain->left = 1; // If the train has left from an intermediate stop, it has automatically left from its first stop!
+                }
             }
 
             // Sanity check: ensure that the arrived/left status for intermediate stops is correct.

--- a/api/data/NMBS/Disturbances.php
+++ b/api/data/NMBS/Disturbances.php
@@ -136,13 +136,21 @@ class Disturbances
             // Trim the description from any html
             $disturbance->description = str_replace('<br/>', "\n", $disturbance->description);
 
-            if (strpos($disturbance->description,
-                    '<a href="http://www.belgianrail.be/jp/download/brail_him/') !== false) {
-                preg_match('/<a href="(?P<url>http:\/\/www.belgianrail.be\/jp\/download\/brail_him\/.*?)"/',
-                    $disturbance->description, $documentMatches);
+            if (strpos(
+                $disturbance->description,
+                '<a href="http://www.belgianrail.be/jp/download/brail_him/'
+            ) !== false) {
+                preg_match(
+                    '/<a href="(?P<url>http:\/\/www.belgianrail.be\/jp\/download\/brail_him\/.*?)"/',
+                    $disturbance->description,
+                    $documentMatches
+                );
                 $disturbance->attachment = $documentMatches['url'];
-                $disturbance->description = preg_replace('/<a href="http:\/\/www.belgianrail.be\/jp\/download\/brail_him\/.*?">.*?<\/a>/',
-                    '', $disturbance->description);
+                $disturbance->description = preg_replace(
+                    '/<a href="http:\/\/www.belgianrail.be\/jp\/download\/brail_him\/.*?">.*?<\/a>/',
+                    '',
+                    $disturbance->description
+                );
             }
 
             $disturbance->description = trim((String)$item->description, "\r\n ");

--- a/api/data/NMBS/Liveboard.php
+++ b/api/data/NMBS/Liveboard.php
@@ -43,13 +43,23 @@ class Liveboard
      */
     private static function fillDataRootWithArrivalData(DataRoot $dataroot, LiveboardRequest $request): void
     {
-        $nmbsCacheKey = self::getNmbsCacheKey($dataroot->station, $request->getTime(), $request->getDate(),
-            $request->getLang(), 'arr');
+        $nmbsCacheKey = self::getNmbsCacheKey(
+            $dataroot->station,
+            $request->getTime(),
+            $request->getDate(),
+            $request->getLang(),
+            'arr'
+        );
         $xml = Tools::getCachedObject($nmbsCacheKey);
 
         if ($xml === false) {
-            $xml = self::fetchDataFromNmbs($dataroot->station, $request->getTime(), $request->getDate(),
-                $request->getLang(), 'arr');
+            $xml = self::fetchDataFromNmbs(
+                $dataroot->station,
+                $request->getTime(),
+                $request->getDate(),
+                $request->getLang(),
+                'arr'
+            );
 
             if (empty($xml)) {
                 throw new Exception("No response from NMBS/SNCB", 504);
@@ -70,13 +80,23 @@ class Liveboard
      */
     private static function FillDataRootWithDepartureData(DataRoot $dataroot, LiveboardRequest $request): void
     {
-        $nmbsCacheKey = self::getNmbsCacheKey($dataroot->station, $request->getTime(), $request->getDate(),
-            $request->getLang(), 'dep');
+        $nmbsCacheKey = self::getNmbsCacheKey(
+            $dataroot->station,
+            $request->getTime(),
+            $request->getDate(),
+            $request->getLang(),
+            'dep'
+        );
         $html = Tools::getCachedObject($nmbsCacheKey);
 
         if ($html === false) {
-            $html = self::fetchDataFromNmbs($dataroot->station, $request->getTime(), $request->getDate(),
-                $request->getLang(), 'dep');
+            $html = self::fetchDataFromNmbs(
+                $dataroot->station,
+                $request->getTime(),
+                $request->getDate(),
+                $request->getLang(),
+                'dep'
+            );
             Tools::setCachedObject($nmbsCacheKey, $html);
         } else {
             Tools::sendIrailCacheResponseHeader(true);
@@ -295,8 +315,10 @@ class Liveboard
             // $stopAtStation->partiallyCanceled = $partiallyCanceled;
             $stopAtStation->left = $left;
             $stopAtStation->isExtra = $isExtraTrain;
-            $stopAtStation->departureConnection = 'http://irail.be/connections/' . substr(basename($currentStation->{'@id'}),
-                    2) . '/' . date('Ymd', $unixtime) . '/' . $vehicle->name;
+            $stopAtStation->departureConnection = 'http://irail.be/connections/' . substr(
+                basename($currentStation->{'@id'}),
+                2
+            ) . '/' . date('Ymd', $unixtime) . '/' . $vehicle->name;
 
             // Add occuppancy data, if available
             $stopAtStation = self::getDepartureArrivalWithAddedOccuppancyData($currentStation, $stopAtStation, $date);
@@ -403,8 +425,11 @@ class Liveboard
 
             $remark = new StdClass();
             $remark->code = $rawRemark['code'];
-            $remark->description = strip_tags(preg_replace("/<a href=\".*?\">.*?<\/a>/", '',
-                $rawRemark['txtN']));
+            $remark->description = strip_tags(preg_replace(
+                "/<a href=\".*?\">.*?<\/a>/",
+                '',
+                $rawRemark['txtN']
+            ));
 
             $matches = [];
             preg_match_all("/<a href=\"(.*?)\">.*?<\/a>/", urldecode($rawRemark['txtN']), $matches);
@@ -461,10 +486,14 @@ class Liveboard
             }
 
             if (key_exists('pubChL', $rawAlert)) {
-                $alert->startTime = Tools::transformTime($rawAlert['pubChL'][0]['fTime'],
-                    $rawAlert['pubChL'][0]['fDate']);
-                $alert->endTime = Tools::transformTime($rawAlert['pubChL'][0]['tTime'],
-                    $rawAlert['pubChL'][0]['tDate']);
+                $alert->startTime = Tools::transformTime(
+                    $rawAlert['pubChL'][0]['fTime'],
+                    $rawAlert['pubChL'][0]['fDate']
+                );
+                $alert->endTime = Tools::transformTime(
+                    $rawAlert['pubChL'][0]['tTime'],
+                    $rawAlert['pubChL'][0]['tDate']
+                );
             }
 
             $alertDefinitions[] = $alert;
@@ -582,11 +611,19 @@ class Liveboard
     private static function parseDelayInSeconds($stop, $date): int
     {
         if (key_exists('dTimeR', $stop['stbStop'])) {
-            $delay = Tools::calculateSecondsHHMMSS($stop['stbStop']['dTimeR'],
-                $date, $stop['stbStop']['dTimeS'], $date);
+            $delay = Tools::calculateSecondsHHMMSS(
+                $stop['stbStop']['dTimeR'],
+                $date,
+                $stop['stbStop']['dTimeS'],
+                $date
+            );
         } elseif (key_exists('aTimeR', $stop['stbStop'])) {
-            $delay = Tools::calculateSecondsHHMMSS($stop['stbStop']['aTimeR'],
-                $date, $stop['stbStop']['aTimeS'], $date);
+            $delay = Tools::calculateSecondsHHMMSS(
+                $stop['stbStop']['aTimeR'],
+                $date,
+                $stop['stbStop']['aTimeS'],
+                $date
+            );
         } else {
             $delay = 0;
         }
@@ -605,8 +642,11 @@ class Liveboard
     {
         if (!is_null($currentStation)) {
             try {
-                $occupancy = OccupancyOperations::getOccupancyURI($stopAtStation->vehicle->{'@id'},
-                    $currentStation->{'@id'}, $date);
+                $occupancy = OccupancyOperations::getOccupancyURI(
+                    $stopAtStation->vehicle->{'@id'},
+                    $currentStation->{'@id'},
+                    $date
+                );
 
                 // Check if the MongoDB module is set up. If not, the occupancy score will not be returned.
                 if (!is_null($occupancy)) {

--- a/api/data/NMBS/Tools.php
+++ b/api/data/NMBS/Tools.php
@@ -187,9 +187,9 @@ class Tools
             'Ymd',
             $departureTime
         ) . '/' . substr(
-                    $vehicleId,
-                    strrpos($vehicleId, '.') + 1
-                );
+            $vehicleId,
+            strrpos($vehicleId, '.') + 1
+        );
     }
 
     public static function getUserAgent(): string

--- a/api/data/NMBS/Tools.php
+++ b/api/data/NMBS/Tools.php
@@ -180,10 +180,16 @@ class Tools
 
     public static function createDepartureUri(Station $station, $departureTime, string $vehicleId): string
     {
-        return 'http://irail.be/connections/' . substr(basename($station->{'@id'}),
-                2) . '/' . date('Ymd',
-                $departureTime) . '/' . substr($vehicleId,
-                strrpos($vehicleId, '.') + 1);
+        return 'http://irail.be/connections/' . substr(
+            basename($station->{'@id'}),
+            2
+        ) . '/' . date(
+                    'Ymd',
+                    $departureTime
+                ) . '/' . substr(
+                    $vehicleId,
+                    strrpos($vehicleId, '.') + 1
+                );
     }
 
     public static function getUserAgent(): string

--- a/api/data/NMBS/Tools.php
+++ b/api/data/NMBS/Tools.php
@@ -184,9 +184,9 @@ class Tools
             basename($station->{'@id'}),
             2
         ) . '/' . date(
-                    'Ymd',
-                    $departureTime
-                ) . '/' . substr(
+            'Ymd',
+            $departureTime
+        ) . '/' . substr(
                     $vehicleId,
                     strrpos($vehicleId, '.') + 1
                 );

--- a/api/data/NMBS/VehicleInformation.php
+++ b/api/data/NMBS/VehicleInformation.php
@@ -59,8 +59,10 @@ class VehicleInformation
             $dataroot->alert = self::getAlerts($html, $request->getFormat());
         }
 
-        $vehicleOccupancy = OccupancyOperations::getOccupancy($dataroot->vehicle->{'@id'},
-            DateTime::createFromFormat('dmy', $date)->format('Ymd'));
+        $vehicleOccupancy = OccupancyOperations::getOccupancy(
+            $dataroot->vehicle->{'@id'},
+            DateTime::createFromFormat('dmy', $date)->format('Ymd')
+        );
 
         // Use this to check if the MongoDB module is set up. If not, the occupancy score will not be returned
         if (!is_null($vehicleOccupancy)) {
@@ -70,8 +72,15 @@ class VehicleInformation
         $lastStop = null;
 
         $dataroot->stop = [];
-        $dataroot->stop = self::getData($html, $lang, $request->getFast(), $vehicleOccupancy, $date,
-            $request->getVehicleId(), $lastStop);
+        $dataroot->stop = self::getData(
+            $html,
+            $lang,
+            $request->getFast(),
+            $vehicleOccupancy,
+            $date,
+            $request->getVehicleId(),
+            $lastStop
+        );
 
         // When fast=true, this data will not be available
         if (property_exists($lastStop, "locationX")) {
@@ -323,8 +332,10 @@ class VehicleInformation
                 $stops[$j]->arrivalCanceled = $arrivalCanceled;
 
                 if ($fast != 'true') {
-                    $stops[$j]->departureConnection = 'http://irail.be/connections/' . substr(basename($stops[$j]->station->{'@id'}),
-                            2) . '/' . $dateDatetime->format('Ymd') . '/' . substr($vehicle, 8);
+                    $stops[$j]->departureConnection = 'http://irail.be/connections/' . substr(
+                        basename($stops[$j]->station->{'@id'}),
+                        2
+                    ) . '/' . $dateDatetime->format('Ymd') . '/' . substr($vehicle, 8);
                 }
                 $stops[$j]->platform = new Platform($platform, $normalplatform);
                 //for backward compatibility

--- a/api/output/Printer.php
+++ b/api/output/Printer.php
@@ -30,8 +30,10 @@ abstract class Printer
         $this->printCacheHeaders($etag);
 
         $headers = $this->getallheaders();
-        if (key_exists('If-None-Match',
-                $headers) && ($headers['If-None-Match'] == '"' . $etag . '"' || $headers['If-None-Match'] == 'W/"' . $etag . '"')) {
+        if (key_exists(
+            'If-None-Match',
+            $headers
+        ) && ($headers['If-None-Match'] == '"' . $etag . '"' || $headers['If-None-Match'] == 'W/"' . $etag . '"')) {
             // Print the unchanged response code. Don't transmit a body
             http_response_code("304");
             return;
@@ -149,8 +151,10 @@ abstract class Printer
             $this->startKeyVal($key, $val);
             $this->endElement($key);
         } else {
-            throw new Exception('Could not retrieve the right information - please report this problem to iRail@list.iRail.be or try again with other arguments.',
-                500);
+            throw new Exception(
+                'Could not retrieve the right information - please report this problem to iRail@list.iRail.be or try again with other arguments.',
+                500
+            );
         }
     }
 


### PR DESCRIPTION
This PR fixes a case where the routeplanner endpoint contained trains that weren't reported as left from the departure station, but were already arrived at the next intermediate station. In case a train has arrived at an intermediate station, it is automatically marked as left from the departure station.

Example incorrect data:

```
<connections version="1.1" timestamp="1596193821">
	<connection id="0">
		<departure delay="0" canceled="0" left="0" walking="0">
			<station locationX="4.672188" locationY="50.90353" id="BE.NMBS.008811288" URI="http://irail.be/stations/NMBS/008811288" standardname="Herent">Herent</station>
			<time formatted="2020-07-31T12:58:00">1596193080</time>
			<vehicle>BE.NMBS.S93284</vehicle>
			<platform normal="1">1</platform>
			<stops number="4">
				<stop id="0" arrived="1" left="0" isExtraStop="0">
					<station locationX="4.543301" locationY="50.893067" id="BE.NMBS.008811254" URI="http://irail.be/stations/NMBS/008811254" standardname="Kortenberg">Kortenberg</station>
					<scheduledArrivalTime formatted="2020-07-31T13:05:00">1596193500</scheduledArrivalTime>
					<arrivalCanceled>0</arrivalCanceled>
					<arrivalDelay>0</arrivalDelay>
					<scheduledDepartureTime formatted="2020-07-31T13:05:00">1596193500</scheduledDepartureTime>
					<departureDelay>0</departureDelay>
					<departureCanceled>0</departureCanceled>
					<departureConnection>
					http://irail.be/connections/8811254/20200731/S93284
					</departureConnection>
				</stop>
...
			</stops>
...
		</departure>
...
	</connection>
...
</connections>
```