### PR TITLE
Add tests to ensure the XML root elements are always correct. Fixes #423

### DIFF
--- a/tests/integration/ConnectionsIntegrationTest.php
+++ b/tests/integration/ConnectionsIntegrationTest.php
@@ -53,6 +53,13 @@ class ConnectionsIntegrationTest extends IntegrationTestCase
         self::assertEquals("BE.NMBS.008814001", $xml->connection[0]->arrival->station->attributes()['id']);
     }
 
+    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "connections.php?from=Gent-Dampoort&to=Brussel-zuid");
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
+        self::assertTrue(strpos($response->getBody(), "<connections ") === 0, "Root element name should be 'connections'");
+    }
+
     public function test_json_missingParameters_shouldReturn400()
     {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "connections.php?format=json");

--- a/tests/integration/ConnectionsIntegrationTest.php
+++ b/tests/integration/ConnectionsIntegrationTest.php
@@ -53,7 +53,8 @@ class ConnectionsIntegrationTest extends IntegrationTestCase
         self::assertEquals("BE.NMBS.008814001", $xml->connection[0]->arrival->station->attributes()['id']);
     }
 
-    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+    public function test_xml_validParameters_shouldHaveCorrectRootElement()
+    {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "connections.php?from=Gent-Dampoort&to=Brussel-zuid");
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);

--- a/tests/integration/DisturbancesIntegrationTest.php
+++ b/tests/integration/DisturbancesIntegrationTest.php
@@ -16,7 +16,8 @@ class DisturbancesIntegrationTest extends IntegrationTestCase
     }
 
 
-    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+    public function test_xml_validParameters_shouldHaveCorrectRootElement()
+    {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "disturbances.php");
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);

--- a/tests/integration/DisturbancesIntegrationTest.php
+++ b/tests/integration/DisturbancesIntegrationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace Tests\integration;
+
+class DisturbancesIntegrationTest extends IntegrationTestCase
+{
+    public function test_xml_noParameters_shouldReturn200()
+    {
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "disturbances.php");
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
+        self::assertTrue(strpos($response->getBody(), "<disturbances ") === 0, "Root element name should be 'disturbances'");
+        $xml = simplexml_load_string($response->getBody());
+        self::assertTrue(count($xml->disturbance) > 0, "There should be at least one disturbance");
+    }
+
+
+    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "disturbances.php");
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
+        self::assertTrue(strpos($response->getBody(), "<disturbances ") === 0, "Root element name should be 'disturbances'");
+    }
+
+
+    public function test_json_noParameters_shouldReturn200()
+    {
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "disturbances.php?format=json");
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals("application/json;charset=UTF-8", $response->getHeader("content-type")[0]);
+
+        $json = json_decode($response->getBody(), true);
+        self::assertTrue(count($json["disturbance"]) > 0, "There should be at least one disturbance");
+        self::assertTrue(key_exists("title", $json["disturbance"][0]));
+        self::assertTrue(key_exists("description", $json["disturbance"][0]));
+        self::assertTrue(key_exists("timestamp", $json["disturbance"][0]));
+    }
+}

--- a/tests/integration/LiveboardIntegrationTest.php
+++ b/tests/integration/LiveboardIntegrationTest.php
@@ -24,16 +24,24 @@ class LiveboardIntegrationTest extends IntegrationTestCase
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
     }
 
+    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "liveboard.php?station=Welkenraedt");
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
+        self::assertTrue(strpos($response->getBody(), "<liveboard ") === 0, "Root element name should be 'liveboard'");
+    }
+
     public function test_xml_validParameters_shouldReturn200()
     {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "liveboard.php?id=008844503");
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
 
-        $response = self::getClient()->request("GET", self::getBaseUrl() . "liveboard.php?station=Welkenraedt");
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "liveboard.php?station=Welkenraedt&time=1300");
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
 
+        self::assertTrue(strpos($response->getBody(), "<liveboard ") === 0, "Root element name should be 'liveboard'");
         $xml = simplexml_load_string($response->getBody());
         self::assertEquals("Welkenraedt", $xml->station);
         self::assertTrue(count($xml->departures->departure) > 0, "Liveboard should at least have one departure");

--- a/tests/integration/LiveboardIntegrationTest.php
+++ b/tests/integration/LiveboardIntegrationTest.php
@@ -24,7 +24,8 @@ class LiveboardIntegrationTest extends IntegrationTestCase
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
     }
 
-    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+    public function test_xml_validParameters_shouldHaveCorrectRootElement()
+    {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "liveboard.php?station=Welkenraedt");
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);

--- a/tests/integration/StationsIntegrationTest.php
+++ b/tests/integration/StationsIntegrationTest.php
@@ -12,7 +12,8 @@ class StationsIntegrationTest extends IntegrationTestCase
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
     }
 
-    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+    public function test_xml_validParameters_shouldHaveCorrectRootElement()
+    {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "stations.php");
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);

--- a/tests/integration/StationsIntegrationTest.php
+++ b/tests/integration/StationsIntegrationTest.php
@@ -12,6 +12,13 @@ class StationsIntegrationTest extends IntegrationTestCase
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
     }
 
+    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "stations.php");
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
+        self::assertTrue(strpos($response->getBody(), "<stations ") === 0, "Root element name should be 'stations'");
+    }
+
     public function test_json_noParameters_shouldReturn200()
     {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "stations.php?format=json");

--- a/tests/integration/VehicleIntegrationTest.php
+++ b/tests/integration/VehicleIntegrationTest.php
@@ -35,6 +35,13 @@ class VehicleIntegrationTest extends IntegrationTestCase
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
     }
 
+    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+        $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?id=IC538");
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
+        self::assertTrue(strpos($response->getBody(), "<vehicleinformation ") === 0, "Root element name should be 'vehicleinformation'");
+    }
+
     public function test_xml_validParametersNoTrainType_shouldReturn200()
     {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?id=538");

--- a/tests/integration/VehicleIntegrationTest.php
+++ b/tests/integration/VehicleIntegrationTest.php
@@ -35,7 +35,8 @@ class VehicleIntegrationTest extends IntegrationTestCase
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);
     }
 
-    public function test_xml_validParameters_shouldHaveCorrectRootElement(){
+    public function test_xml_validParameters_shouldHaveCorrectRootElement()
+    {
         $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?id=IC538");
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals("application/xml;charset=UTF-8", $response->getHeader("content-type")[0]);


### PR DESCRIPTION
This PR adds tests to ensure that bugs such as the one described in #423 don't happen again