### PR TITLE
Add clear error message when making a liveboard query with an invalid date, fixes #392

### DIFF
--- a/src/api/data/NMBS/tools/HafasCommon.php
+++ b/src/api/data/NMBS/tools/HafasCommon.php
@@ -28,6 +28,9 @@ class HafasCommon
         if ($json['svcResL'][0]['err'] == "H890") {
             throw new Exception('No results found', 404);
         }
+        if ($json['svcResL'][0]['err'] == 'PROBLEMS') {
+            throw new Exception("Date likely outside of the timetable period. Check your query.", 400);
+        }
         if ($json['svcResL'][0]['err'] != 'OK') {
             throw new Exception("This request failed. Please check your query. Error code " . $json['svcResL'][0]['err'], 500);
         }

--- a/tests/integration/VehicleIntegrationTest.php
+++ b/tests/integration/VehicleIntegrationTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\integration;
 
+use DateTime;
+use DateTimeZone;
 use GuzzleHttp\Exception\GuzzleException;
 
 class VehicleIntegrationTest extends IntegrationTestCase
@@ -197,8 +199,12 @@ class VehicleIntegrationTest extends IntegrationTestCase
         $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?format=json&id=IC538");
         $this->assertEquals(200, $response->getStatusCode());
 
-        $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?format=json&id=S103890");
-        $this->assertEquals(200, $response->getStatusCode());
+        if (!self::isTodayWeekend()) {
+            // Todo: we should be able to specify the date here
+            // S Trains can only be tested during the week, unfortunately
+            $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?format=json&id=S103890");
+            $this->assertEquals(200, $response->getStatusCode());
+        }
     }
 
     /**
@@ -209,8 +215,14 @@ class VehicleIntegrationTest extends IntegrationTestCase
     {
         $response = self::getClient()->request(
             "GET",
-            self::getBaseUrl() . "vehicle.php?format=json&id=S102063&alerts=true"
+            self::getBaseUrl() . "vehicle.php?format=json&id=IC538&alerts=true"
         );
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    private static function isTodayWeekend()
+    {
+        $currentDate = new DateTime("now", new DateTimeZone("Europe/Brussels"));
+        return $currentDate->format('N') >= 6;
     }
 }


### PR DESCRIPTION
Clear error message for error code problems, caused by an invalid date parameter in liveboard queries. Fixes #392