### PR TITLE
Fix unstable integration tests due to certain trains not driving on weekends

### DIFF
--- a/tests/integration/VehicleIntegrationTest.php
+++ b/tests/integration/VehicleIntegrationTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\integration;
 
+use DateTime;
+use DateTimeZone;
 use GuzzleHttp\Exception\GuzzleException;
 
 class VehicleIntegrationTest extends IntegrationTestCase
@@ -197,8 +199,12 @@ class VehicleIntegrationTest extends IntegrationTestCase
         $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?format=json&id=IC538");
         $this->assertEquals(200, $response->getStatusCode());
 
-        $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?format=json&id=S103890");
-        $this->assertEquals(200, $response->getStatusCode());
+        if (!self::isTodayWeekend()) {
+            // Todo: we should be able to specify the date here
+            // S Trains can only be tested during the week, unfortunately
+            $response = self::getClient()->request("GET", self::getBaseUrl() . "vehicle.php?format=json&id=S103890");
+            $this->assertEquals(200, $response->getStatusCode());
+        }
     }
 
     /**
@@ -209,8 +215,14 @@ class VehicleIntegrationTest extends IntegrationTestCase
     {
         $response = self::getClient()->request(
             "GET",
-            self::getBaseUrl() . "vehicle.php?format=json&id=S102063&alerts=true"
+            self::getBaseUrl() . "vehicle.php?format=json&id=IC538&alerts=true"
         );
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    private static function isTodayWeekend()
+    {
+        $currentDate = new DateTime("now", new DateTimeZone("Europe/Brussels"));
+        return $currentDate->format('N') >= 6;
     }
 }


### PR DESCRIPTION
Travis-CI cron jobs fali every now and then due to a train not driving on weekends. We still want to check this train on weekdays, so added a check to only test the S train on weekdays.