### PR TITLE
Removed stripping of <a> tags from disturbances end point for descriptions

### DIFF
--- a/src/api/data/NMBS/DisturbancesDatasource.php
+++ b/src/api/data/NMBS/DisturbancesDatasource.php
@@ -180,7 +180,10 @@ class DisturbancesDatasource
                 " " . $newlinePlaceHolder,
                 $disturbance->description
             );
-            $disturbance->description = preg_replace('/<.*?>/', '', $disturbance->description);
+
+            // Strip all html tags except anchor tags <a>
+            $disturbance->description = preg_replace('/<(?!a ).*?[^a]>/', '', $disturbance->description);
+
             $disturbance->description = preg_replace(
                 "/(Info (NL|FR|DE|EN)( |$newlinePlaceHolder)+)+$/",
                 "",


### PR DESCRIPTION
The disturbances endpoint will no longer remove anchor tags from disturbance descriptions

Closes #407 