### PR TITLE
Merge development to master, fix #434

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "irail/stations": "^1.6.4",
+    "irail/stations": "^1.6.6",
     "monolog/monolog": "^1.25",
     "ptachoire/tac": "1.0.*",
     "sebastian/environment": "4.2.*",
@@ -29,7 +29,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5.8",
-    "guzzlehttp/guzzle": "^7.0",
+    "guzzlehttp/guzzle": "^7.2",
     "symfony/process": "^v5.1"
   },
   "scripts": {

--- a/src/api/data/NMBS/ConnectionsDatasource.php
+++ b/src/api/data/NMBS/ConnectionsDatasource.php
@@ -791,7 +791,10 @@ class ConnectionsDatasource
 
         $parsedTrain->isPartiallyCancelled = false;
         $parsedTrain->stops = [];
-        if (key_exists('jny', $trainRide)) {
+        if (key_exists('jny', $trainRide) && key_exists('stopL',$trainRide['jny'])) {
+            // If the list of stops is not present, the NMBS is outputting faulty data. It means the train is broken
+            // on their website as well.
+
             if (key_exists('isPartCncl', $trainRide['jny'])) {
                 $parsedTrain->isPartiallyCancelled = $trainRide['jny']['isPartCncl'];
             }

--- a/src/api/data/NMBS/ConnectionsDatasource.php
+++ b/src/api/data/NMBS/ConnectionsDatasource.php
@@ -791,7 +791,7 @@ class ConnectionsDatasource
 
         $parsedTrain->isPartiallyCancelled = false;
         $parsedTrain->stops = [];
-        if (key_exists('jny', $trainRide) && key_exists('stopL',$trainRide['jny'])) {
+        if (key_exists('jny', $trainRide) && key_exists('stopL', $trainRide['jny'])) {
             // If the list of stops is not present, the NMBS is outputting faulty data. It means the train is broken
             // on their website as well.
 

--- a/src/api/output/Printer.php
+++ b/src/api/output/Printer.php
@@ -145,23 +145,17 @@ abstract class Printer
     private function printElement($key, $val, $root = false)
     {
         if (is_array($val)) {
-            if (count($val) > 0) {
-                $this->startArray($key, count($val), $root);
-                $i = 0;
-                foreach ($val as $elementval) {
-                    $this->printElement($key, $elementval);
-                    // Keep count of where we are, and as long as this isn't the last element, print the array divider
-                    if ($i < (count($val) - 1)) {
-                        $this->nextArrayElement();
-                    }
-                    $i++;
+            $this->startArray($key, count($val), $root);
+            $i = 0;
+            foreach ($val as $elementval) {
+                $this->printElement($key, $elementval);
+                // Keep count of where we are, and as long as this isn't the last element, print the array divider
+                if ($i < (count($val) - 1)) {
+                    $this->nextArrayElement();
                 }
-                $this->endArray($key, $root);
-            } else {
-                //very dirty fix of the komma problem when empty array when this would occur
-                $this->startKeyVal('empty', '');
-                $this->endElement('empty');
+                $i++;
             }
+            $this->endArray($key, $root);
         } elseif (is_object($val)) {
             $this->startObject($key, $val);
             $allObjectVars = get_object_vars($val);

--- a/tests/unit/api/data/NMBS/ConnectionsDatasourceTest.php
+++ b/tests/unit/api/data/NMBS/ConnectionsDatasourceTest.php
@@ -48,5 +48,4 @@ class ConnectionsDatasourceTest extends TestCase
         self::assertNotNull($connections);
         self::assertEquals(10, count($connections));
     }
-
 }

--- a/tests/unit/api/data/NMBS/ConnectionsDatasourceTest.php
+++ b/tests/unit/api/data/NMBS/ConnectionsDatasourceTest.php
@@ -5,6 +5,7 @@ namespace Tests\unit\api\data\NMBS;
 use Exception;
 use Irail\api\data\NMBS\ConnectionsDatasource;
 use Irail\api\data\NMBS\StationsDatasource;
+use Irail\api\requests\ConnectionsRequest;
 use PHPUnit\Framework\TestCase;
 
 class ConnectionsDatasourceTest extends TestCase
@@ -12,7 +13,7 @@ class ConnectionsDatasourceTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testCreateNmbsPayload()
+    public function test_CreateNmbsPayload_shouldCreateValidPayload()
     {
         $from = StationsDatasource::getStationFromName("Brussel-zuid", "NL");
         $to = StationsDatasource::getStationFromName("Brussel-noord", "NL");
@@ -39,4 +40,13 @@ class ConnectionsDatasourceTest extends TestCase
         self::assertEquals(1, $this->count($payloadArray['svcReqL']));
         self::assertArrayHasKey('ver', $payloadArray);
     }
+
+    public function test_regression434_connectionMissingStops_shouldBeParsedCorrectly()
+    {
+        $serverData = file_get_contents(__DIR__ . "/fixtures/connections-issue434.json");
+        $connections = ConnectionsDatasource::parseConnectionsAPI($serverData, "en",  $this->createMock(ConnectionsRequest::class));
+        self::assertNotNull($connections);
+        self::assertEquals(10, count($connections));
+    }
+
 }

--- a/tests/unit/api/data/NMBS/ConnectionsDatasourceTest.php
+++ b/tests/unit/api/data/NMBS/ConnectionsDatasourceTest.php
@@ -44,7 +44,7 @@ class ConnectionsDatasourceTest extends TestCase
     public function test_regression434_connectionMissingStops_shouldBeParsedCorrectly()
     {
         $serverData = file_get_contents(__DIR__ . "/fixtures/connections-issue434.json");
-        $connections = ConnectionsDatasource::parseConnectionsAPI($serverData, "en",  $this->createMock(ConnectionsRequest::class));
+        $connections = ConnectionsDatasource::parseConnectionsAPI($serverData, "en", $this->createMock(ConnectionsRequest::class));
         self::assertNotNull($connections);
         self::assertEquals(10, count($connections));
     }

--- a/tests/unit/api/data/NMBS/fixtures/connections-issue434.json
+++ b/tests/unit/api/data/NMBS/fixtures/connections-issue434.json
@@ -1,0 +1,6050 @@
+{
+  "ver": "1.21",
+  "lang": "fra",
+  "id": "n9k63gqkgagd8wck",
+  "err": "OK",
+  "svcResL": [
+    {
+      "meth": "TripSearch",
+      "err": "OK",
+      "res": {
+        "common": {
+          "locL": [
+            {
+              "lid": "A=1@O=Melreux-Hotton@X=5440137@Y=50283671@U=80@L=8864436@",
+              "type": "S",
+              "name": "Melreux-Hotton",
+              "icoX": 0,
+              "extId": "8864436",
+              "state": "F",
+              "crd": {
+                "x": 5440137,
+                "y": 50283671,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Huy@X=5234212@Y=50527242@U=80@L=8843307@",
+              "type": "S",
+              "name": "Huy",
+              "icoX": 0,
+              "extId": "8843307",
+              "state": "F",
+              "crd": {
+                "x": 5234212,
+                "y": 50527242,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Marloie@X=5313892@Y=50202822@U=80@L=8864345@",
+              "type": "S",
+              "name": "Marloie",
+              "icoX": 0,
+              "extId": "8864345",
+              "state": "F",
+              "crd": {
+                "x": 5313892,
+                "y": 50202822,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Marche-en-Famenne@X=5346289@Y=50222472@U=80@L=8864410@",
+              "type": "S",
+              "name": "Marche-en-Famenne",
+              "icoX": 0,
+              "extId": "8864410",
+              "state": "F",
+              "crd": {
+                "x": 5346289,
+                "y": 50222472,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Namur@X=4862220@Y=50468794@U=80@L=8863008@",
+              "type": "S",
+              "name": "Namur",
+              "icoX": 0,
+              "extId": "8863008",
+              "state": "F",
+              "crd": {
+                "x": 4862220,
+                "y": 50468794,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 628
+            },
+            {
+              "lid": "A=1@O=Ciney@X=5091409@Y=50291051@U=80@L=8864501@",
+              "type": "S",
+              "name": "Ciney",
+              "icoX": 0,
+              "extId": "8864501",
+              "state": "F",
+              "crd": {
+                "x": 5091409,
+                "y": 50291051,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Andenne@X=5094699@Y=50496769@U=80@L=8863404@",
+              "type": "S",
+              "name": "Andenne",
+              "icoX": 0,
+              "extId": "8863404",
+              "state": "F",
+              "crd": {
+                "x": 5094699,
+                "y": 50496769,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Statte@X=5219676@Y=50528276@U=80@L=8843406@",
+              "type": "S",
+              "name": "Statte",
+              "icoX": 0,
+              "extId": "8843406",
+              "state": "F",
+              "crd": {
+                "x": 5219676,
+                "y": 50528276,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Marche-les-Dames@X=4964581@Y=50480741@U=80@L=8863461@",
+              "type": "S",
+              "name": "Marche-les-Dames",
+              "icoX": 0,
+              "extId": "8863461",
+              "state": "F",
+              "crd": {
+                "x": 4964581,
+                "y": 50480741,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Namêche@X=4997939@Y=50470430@U=80@L=8863453@",
+              "type": "S",
+              "name": "Namêche",
+              "icoX": 0,
+              "extId": "8863453",
+              "state": "F",
+              "crd": {
+                "x": 4997939,
+                "y": 50470430,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Sclaigneaux@X=5026363@Y=50492238@U=80@L=8863446@",
+              "type": "S",
+              "name": "Sclaigneaux",
+              "icoX": 0,
+              "extId": "8863446",
+              "state": "F",
+              "crd": {
+                "x": 5026363,
+                "y": 50492238,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Château-de-Seilles@X=5081746@Y=50497209@U=80@L=8863438@",
+              "type": "S",
+              "name": "Château-de-Seilles",
+              "icoX": 0,
+              "extId": "8863438",
+              "state": "F",
+              "crd": {
+                "x": 5081746,
+                "y": 50497209,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Bas-Oha@X=5190938@Y=50522631@U=80@L=8843430@",
+              "type": "S",
+              "name": "Bas-Oha",
+              "icoX": 0,
+              "extId": "8843430",
+              "state": "F",
+              "crd": {
+                "x": 5190938,
+                "y": 50522631,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Liège-Guillemins@X=5566696@Y=50624551@U=80@L=8841004@",
+              "type": "S",
+              "name": "Liège-Guillemins",
+              "icoX": 0,
+              "extId": "8841004",
+              "state": "F",
+              "crd": {
+                "x": 5566696,
+                "y": 50624551,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 629
+            },
+            {
+              "lid": "A=1@O=Barvaux@X=5501542@Y=50349418@U=80@L=8864451@",
+              "type": "S",
+              "name": "Barvaux",
+              "icoX": 0,
+              "extId": "8864451",
+              "state": "F",
+              "crd": {
+                "x": 5501542,
+                "y": 50349418,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Bomal@X=5519305@Y=50376799@U=80@L=8864469@",
+              "type": "S",
+              "name": "Bomal",
+              "icoX": 0,
+              "extId": "8864469",
+              "state": "F",
+              "crd": {
+                "x": 5519305,
+                "y": 50376799,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Sy@X=5523566@Y=50403263@U=80@L=8842853@",
+              "type": "S",
+              "name": "Sy",
+              "icoX": 0,
+              "extId": "8842853",
+              "state": "F",
+              "crd": {
+                "x": 5523566,
+                "y": 50403263,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 68
+            },
+            {
+              "lid": "A=1@O=Hamoir@X=5533562@Y=50428181@U=80@L=8842846@",
+              "type": "S",
+              "name": "Hamoir",
+              "icoX": 0,
+              "extId": "8842846",
+              "state": "F",
+              "crd": {
+                "x": 5533562,
+                "y": 50428181,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Comblain-la-Tour@X=5566957@Y=50456857@U=80@L=8842838@",
+              "type": "S",
+              "name": "Comblain-la-Tour",
+              "icoX": 0,
+              "extId": "8842838",
+              "state": "F",
+              "crd": {
+                "x": 5566957,
+                "y": 50456857,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 580
+            },
+            {
+              "lid": "A=1@O=Rivage@X=5587632@Y=50483276@U=80@L=8842705@",
+              "type": "S",
+              "name": "Rivage",
+              "icoX": 0,
+              "extId": "8842705",
+              "state": "F",
+              "crd": {
+                "x": 5587632,
+                "y": 50483276,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 100
+            },
+            {
+              "lid": "A=1@O=Poulseur@X=5578858@Y=50509210@U=80@L=8842689@",
+              "type": "S",
+              "name": "Poulseur",
+              "icoX": 0,
+              "extId": "8842689",
+              "state": "F",
+              "crd": {
+                "x": 5578858,
+                "y": 50509210,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Esneux@X=5572566@Y=50530559@U=80@L=8842663@",
+              "type": "S",
+              "name": "Esneux",
+              "icoX": 0,
+              "extId": "8842663",
+              "state": "F",
+              "crd": {
+                "x": 5572566,
+                "y": 50530559,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Hony@X=5573564@Y=50539917@U=80@L=8842655@",
+              "type": "S",
+              "name": "Hony",
+              "icoX": 0,
+              "extId": "8842655",
+              "state": "F",
+              "crd": {
+                "x": 5573564,
+                "y": 50539917,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 100
+            },
+            {
+              "lid": "A=1@O=Méry@X=5587236@Y=50547621@U=80@L=8842648@",
+              "type": "S",
+              "name": "Méry",
+              "icoX": 0,
+              "extId": "8842648",
+              "state": "F",
+              "crd": {
+                "x": 5587236,
+                "y": 50547621,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Tilff@X=5583937@Y=50570633@U=80@L=8842630@",
+              "type": "S",
+              "name": "Tilff",
+              "icoX": 0,
+              "extId": "8842630",
+              "state": "F",
+              "crd": {
+                "x": 5583937,
+                "y": 50570633,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 612
+            },
+            {
+              "lid": "A=1@O=Angleur@X=5599830@Y=50613143@U=80@L=8842002@",
+              "type": "S",
+              "name": "Angleur",
+              "icoX": 0,
+              "extId": "8842002",
+              "state": "F",
+              "crd": {
+                "x": 5599830,
+                "y": 50613143,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 628
+            },
+            {
+              "lid": "A=1@O=Flémalle-Haute@X=5457657@Y=50595309@U=80@L=8843208@",
+              "type": "S",
+              "name": "Flémalle-Haute",
+              "icoX": 0,
+              "extId": "8843208",
+              "state": "F",
+              "crd": {
+                "x": 5457657,
+                "y": 50595309,
+                "layerX": 0,
+                "crdSysX": 0
+              },
+              "pCls": 596
+            }
+          ],
+          "prodL": [
+            {
+              "name": "L 5562",
+              "number": "5562",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   5562",
+                "num": "5562",
+                "matchId": "5562",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2136",
+              "number": "2136",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2136",
+                "num": "2136",
+                "matchId": "2136",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2414",
+              "number": "2414",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2414",
+                "num": "2414",
+                "matchId": "2414",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 4965",
+              "number": "4965",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   4965",
+                "num": "4965",
+                "matchId": "4965",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 5586",
+              "number": "5586",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   5586",
+                "num": "5586",
+                "matchId": "5586",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2437",
+              "number": "2437",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2437",
+                "num": "2437",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 3838",
+              "number": "3838",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  3838",
+                "num": "3838",
+                "matchId": "3838",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 5563",
+              "number": "5563",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   5563",
+                "num": "5563",
+                "matchId": "5563",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2415",
+              "number": "2415",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2415",
+                "num": "2415",
+                "matchId": "2415",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2137",
+              "number": "2137",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2137",
+                "num": "2137",
+                "matchId": "2137",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 4966",
+              "number": "4966",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   4966",
+                "num": "4966",
+                "matchId": "4966",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 5587",
+              "number": "5587",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   5587",
+                "num": "5587",
+                "matchId": "5587",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2438",
+              "number": "2438",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2438",
+                "num": "2438",
+                "matchId": "2438",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 5564",
+              "number": "5564",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   5564",
+                "num": "5564",
+                "matchId": "5564",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2416",
+              "number": "2416",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2416",
+                "num": "2416",
+                "matchId": "2416",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2138",
+              "number": "2138",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2138",
+                "num": "2138",
+                "matchId": "2138",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 4967",
+              "number": "4967",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   4967",
+                "num": "4967",
+                "matchId": "4967",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "L 5588",
+              "number": "5588",
+              "icoX": 1,
+              "cls": 64,
+              "prodCtx": {
+                "name": "L   5588",
+                "num": "5588",
+                "matchId": "5588",
+                "catOut": "L       ",
+                "catOutS": "046",
+                "catOutL": "L",
+                "catIn": "046",
+                "catCode": "6",
+                "admin": "88____"
+              }
+            },
+            {
+              "name": "IC 2439",
+              "number": "2439",
+              "icoX": 3,
+              "cls": 4,
+              "prodCtx": {
+                "name": "IC  2439",
+                "num": "2439",
+                "matchId": "2439",
+                "catOut": "IC      ",
+                "catOutS": "007",
+                "catOutL": "IC ",
+                "catIn": "007",
+                "catCode": "2",
+                "admin": "88____"
+              }
+            }
+          ],
+          "polyL": [],
+          "layerL": [
+            {
+              "id": "standard",
+              "name": "standard",
+              "index": 0,
+              "annoCnt": 0
+            }
+          ],
+          "crdSysL": [
+            {
+              "id": "standard",
+              "index": 0,
+              "type": "WGS84"
+            }
+          ],
+          "opL": [],
+          "remL": [
+            {
+              "type": "R",
+              "code": "text.realtime.connection.brokentrip",
+              "icoX": 5,
+              "txtN": "La correspondance ne sera probablement pas atteinte."
+            },
+            {
+              "type": "R",
+              "code": "text.realtime.journey.missed.connection",
+              "icoX": 5,
+              "txtN": "La correspondance ne peut probablement pas être atteinte."
+            },
+            {
+              "type": "R",
+              "code": "SNCB_2090_HINT",
+              "icoX": 6,
+              "txtN": "L'horaire original, planifié de cette relation a été remplacé par un nouveau suite à une déviation. Sur base du nouvel horaire, la correspondance ne peut pas être garantie. Consultez l'aperçu pour un itinéraire alternatif."
+            }
+          ],
+          "himL": [
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                0
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                1
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                2
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                3
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                4
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                5
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                6
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                7
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                8
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                9
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                10
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                11
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                12
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                13
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                14
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                15
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                16
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                17
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                18
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                19
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                20
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                21
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                22
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                23
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                24
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            },
+            {
+              "hid": "45523",
+              "act": true,
+              "head": "Info-voyageurs #MoveSafe",
+              "lead": "Info-voyageurs #MoveSafe",
+              "text": "Le port du masque est obligatoire dans les gares, sur les quais et dans les trains.",
+              "icoX": 2,
+              "prio": 75,
+              "prod": 65535,
+              "lModDate": "20201224",
+              "lModTime": "102627",
+              "sDate": "20200831",
+              "sTime": "000500",
+              "eDate": "20210331",
+              "eTime": "235900",
+              "sDaily": "000000",
+              "eDaily": "235900",
+              "comp": "SNCB",
+              "catRefL": [
+                25
+              ],
+              "pubChL": [
+                {
+                  "name": "timetable",
+                  "fDate": "20200626",
+                  "fTime": "101700",
+                  "tDate": "20210331",
+                  "tTime": "235900"
+                }
+              ]
+            }
+          ],
+          "icoL": [
+            {
+              "res": "STA_SNCB"
+            },
+            {
+              "res": "prod_reg"
+            },
+            {
+              "res": "HIM11"
+            },
+            {
+              "res": "prod_ic"
+            },
+            {
+              "res": "prod_walk"
+            },
+            {
+              "res": "rt_critical"
+            },
+            {
+              "res": "RT"
+            },
+            {
+              "res": "cl_all"
+            }
+          ],
+          "himMsgCatL": [
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            },
+            {
+              "id": 11
+            }
+          ]
+        },
+        "outConL": [
+          {
+            "cid": "C-0",
+            "date": "20210224",
+            "dur": "013300",
+            "chg": 2,
+            "sDays": {
+              "sDaysR": "pas toujours",
+              "sDaysI": "24. Fév",
+              "sDaysB": "00000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 18,
+              "dProdX": 0,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "141100",
+              "dProgType": "PROGNOSED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 34,
+              "aPlatfS": "3",
+              "aOutR": true,
+              "aTimeS": "154400",
+              "aTimeR": "154400",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 18,
+                  "dProdX": 0,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "141100",
+                  "dProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 2,
+                  "idx": 20,
+                  "aPlatfS": "1",
+                  "aOutR": true,
+                  "aTimeS": "142300",
+                  "aProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6994|6|80|24022021",
+                  "prodX": 0,
+                  "dirTxt": "Marloie",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 18,
+                      "aProdX": 0,
+                      "aOutR": true,
+                      "aTimeS": "141000",
+                      "dProdX": 0,
+                      "dInR": true,
+                      "dTimeS": "141100",
+                      "dDirTxt": "Marloie",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 3,
+                      "idx": 19,
+                      "aProdX": 0,
+                      "aOutR": true,
+                      "aTimeS": "141800",
+                      "dProdX": 0,
+                      "dInR": true,
+                      "dTimeS": "141900",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 2,
+                      "idx": 20,
+                      "aProdX": 0,
+                      "aOutR": true,
+                      "aTimeS": "142300",
+                      "aProgType": "PROGNOSED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": -1,
+                  "lPassStRT": {
+                    "idx": -1
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241411$202102241423$L   5562$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 0,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 2,
+                  "dPlatfS": "1",
+                  "dTimeS": "142300"
+                },
+                "arr": {
+                  "locX": 2,
+                  "aPlatfS": "3",
+                  "aTimeS": "142300"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 2,
+                  "idx": 14,
+                  "dProdX": 1,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "143900",
+                  "dTimeR": "143900",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 4,
+                  "idx": 27,
+                  "aProdX": 1,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "151400",
+                  "aTimeR": "151400",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|91424|0|80|24022021",
+                  "prodX": 1,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 2,
+                      "idx": 14,
+                      "aProdX": 1,
+                      "aOutR": true,
+                      "aTimeS": "143800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 1,
+                      "dInR": true,
+                      "dTimeS": "143900",
+                      "dTimeR": "143900",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 5,
+                      "idx": 19,
+                      "aProdX": 1,
+                      "aOutR": true,
+                      "aTimeS": "145400",
+                      "aTimeR": "145400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 1,
+                      "dInR": true,
+                      "dTimeS": "145600",
+                      "dTimeR": "145600",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 4,
+                      "idx": 27,
+                      "aProdX": 1,
+                      "aOutR": true,
+                      "aTimeS": "151400",
+                      "aTimeR": "151400",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "151700",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241439$202102241514$IC  2136$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 1,
+                      "fLocX": 2,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 4,
+                  "dPlatfS": "9",
+                  "dTimeS": "151400"
+                },
+                "arr": {
+                  "locX": 4,
+                  "aPlatfS": "11",
+                  "aTimeS": "151400"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 4,
+                  "idx": 26,
+                  "dProdX": 2,
+                  "dPlatfS": "11",
+                  "dInR": true,
+                  "dTimeS": "151800",
+                  "dTimeR": "151900",
+                  "dProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 34,
+                  "aProdX": 2,
+                  "aPlatfS": "3",
+                  "aOutR": true,
+                  "aTimeS": "154400",
+                  "aTimeR": "154400",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|3154|1|80|24022021",
+                  "prodX": 2,
+                  "dirTxt": "Liège-Saint-Lambert",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 4,
+                      "idx": 26,
+                      "aProdX": 2,
+                      "aOutR": true,
+                      "aTimeS": "151600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 2,
+                      "dInR": true,
+                      "dTimeS": "151800",
+                      "dTimeR": "151900",
+                      "dProgType": "PROGNOSED",
+                      "dDirTxt": "Liège-Saint-Lambert",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 6,
+                      "idx": 31,
+                      "aProdX": 2,
+                      "aOutR": true,
+                      "aTimeS": "153100",
+                      "aTimeR": "153300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 2,
+                      "dInR": true,
+                      "dTimeS": "153200",
+                      "dTimeR": "153300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 7,
+                      "idx": 33,
+                      "aProdX": 2,
+                      "aOutR": true,
+                      "aTimeS": "154000",
+                      "aTimeR": "154000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 2,
+                      "dInR": true,
+                      "dTimeS": "154100",
+                      "dTimeR": "154100",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 34,
+                      "aProdX": 2,
+                      "aOutR": true,
+                      "aTimeS": "154400",
+                      "aTimeR": "154400",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "154500",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 3
+                  },
+                  "ctxRecon": "T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241518$202102241544$IC  2414$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 2,
+                      "fLocX": 4,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241411$202102241423$L   5562$$1$§T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241439$202102241514$IC  2136$$3$§T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241518$202102241544$IC  2414$$3$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "71db988e_3",
+            "cksumDti": "c0ef422c_3"
+          },
+          {
+            "cid": "C-1",
+            "date": "20210224",
+            "dur": "015000",
+            "chg": 2,
+            "sDays": {
+              "sDaysR": "Lu - Ve",
+              "sDaysI": "pas 15. Mar jusq'au 9. Avr 2021, 13., 24. Mai, 21. Jul, 1., 11. Nov",
+              "sDaysB": "0000000000003E7CF9F3E7C0000000F9F3E7CE9F1E7CF9F3E7CF9F367CF9F3E7CF9F3E7CF9F3E7CF8F3A7CF9F3E0"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 18,
+              "dProdX": 0,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "141100",
+              "dProgType": "PROGNOSED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 8,
+              "aProdX": 3,
+              "aPlatfS": "3",
+              "aOutR": true,
+              "aTimeS": "160100",
+              "aTimeR": "160100",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 18,
+                  "dProdX": 0,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "141100",
+                  "dProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 2,
+                  "idx": 20,
+                  "aProdX": 0,
+                  "aPlatfS": "1",
+                  "aOutR": true,
+                  "aTimeS": "142300",
+                  "aProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6994|6|80|24022021",
+                  "prodX": 0,
+                  "dirTxt": "Marloie",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 18,
+                      "aProdX": 0,
+                      "aOutR": true,
+                      "aTimeS": "141000",
+                      "dProdX": 0,
+                      "dInR": true,
+                      "dTimeS": "141100",
+                      "dDirTxt": "Marloie",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 3,
+                      "idx": 19,
+                      "aProdX": 0,
+                      "aOutR": true,
+                      "aTimeS": "141800",
+                      "dProdX": 0,
+                      "dInR": true,
+                      "dTimeS": "141900",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 2,
+                      "idx": 20,
+                      "aProdX": 0,
+                      "aOutR": true,
+                      "aTimeS": "142300",
+                      "aProgType": "PROGNOSED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": -1,
+                  "lPassStRT": {
+                    "idx": -1
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241411$202102241423$L   5562$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 3,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 2,
+                  "dPlatfS": "1",
+                  "dTimeS": "142300"
+                },
+                "arr": {
+                  "locX": 2,
+                  "aPlatfS": "3",
+                  "aTimeS": "142300"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 2,
+                  "idx": 14,
+                  "dProdX": 1,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "143900",
+                  "dTimeR": "143900",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 4,
+                  "idx": 27,
+                  "aProdX": 1,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "151400",
+                  "aTimeR": "151400",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|91424|0|80|24022021",
+                  "prodX": 1,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 2,
+                      "idx": 14,
+                      "aProdX": 1,
+                      "aOutR": true,
+                      "aTimeS": "143800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 1,
+                      "dInR": true,
+                      "dTimeS": "143900",
+                      "dTimeR": "143900",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 5,
+                      "idx": 19,
+                      "aProdX": 1,
+                      "aOutR": true,
+                      "aTimeS": "145400",
+                      "aTimeR": "145400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 1,
+                      "dInR": true,
+                      "dTimeS": "145600",
+                      "dTimeR": "145600",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 4,
+                      "idx": 27,
+                      "aProdX": 1,
+                      "aOutR": true,
+                      "aTimeS": "151400",
+                      "aTimeR": "151400",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "151700",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241439$202102241514$IC  2136$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 4,
+                      "fLocX": 2,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 4,
+                  "dPlatfS": "9",
+                  "dTimeS": "151400"
+                },
+                "arr": {
+                  "locX": 4,
+                  "aPlatfS": "3",
+                  "aTimeS": "151400"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 4,
+                  "idx": 0,
+                  "dProdX": 3,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "152700",
+                  "dTimeR": "152700",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 8,
+                  "aProdX": 3,
+                  "aPlatfS": "3",
+                  "aOutR": true,
+                  "aTimeS": "160100",
+                  "aTimeR": "160100",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6610|1|80|24022021",
+                  "prodX": 3,
+                  "dirTxt": "Liège-Guillemins",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 4,
+                      "idx": 0,
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "152700",
+                      "dTimeR": "152700",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Liège-Guillemins",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 8,
+                      "idx": 1,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "153400",
+                      "aTimeR": "153400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "153400",
+                      "dTimeR": "153400",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 9,
+                      "idx": 2,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "153700",
+                      "aTimeR": "153700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "153700",
+                      "dTimeR": "153800",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 10,
+                      "idx": 3,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "154100",
+                      "aTimeR": "154200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "154100",
+                      "dTimeR": "154200",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 11,
+                      "idx": 4,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "154500",
+                      "aTimeR": "154600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "154500",
+                      "dTimeR": "154600",
+                      "dProgType": "CORRECTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 6,
+                      "idx": 5,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "154700",
+                      "aTimeR": "154800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "154800",
+                      "dTimeR": "154800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 12,
+                      "idx": 6,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "155500",
+                      "aTimeR": "155500",
+                      "aProgType": "REPORTED",
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "155500",
+                      "dTimeR": "155500",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 7,
+                      "idx": 7,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "155800",
+                      "aTimeR": "155800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 3,
+                      "dInR": true,
+                      "dTimeS": "155900",
+                      "dTimeR": "155900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 8,
+                      "aProdX": 3,
+                      "aOutR": true,
+                      "aTimeS": "160100",
+                      "aTimeR": "160100",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "160300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 8
+                  },
+                  "ctxRecon": "T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241527$202102241601$L   4965$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 5,
+                      "fLocX": 4,
+                      "tLocX": 4,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241411$202102241423$L   5562$$1$§T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241439$202102241514$IC  2136$$3$§T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241527$202102241601$L   4965$$1$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "f59075d5_3",
+            "cksumDti": "ec550e00_3"
+          },
+          {
+            "cid": "C-2",
+            "date": "20210224",
+            "dur": "012400",
+            "chg": 1,
+            "sDays": {
+              "sDaysR": "pas toujours",
+              "sDaysB": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 2,
+              "dProdX": 4,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "144600",
+              "dTimeR": "144700",
+              "dProgType": "REPORTED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 13,
+              "aProdX": 5,
+              "aPlatfS": "2",
+              "aOutR": true,
+              "aTimeS": "161000",
+              "aTimeR": "161100",
+              "aProgType": "REPORTED",
+              "type": "N",
+              "aTimeSCh": true
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 2,
+                  "dProdX": 4,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "144600",
+                  "dTimeR": "144700",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 13,
+                  "idx": 15,
+                  "aProdX": 4,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "154300",
+                  "aTimeR": "154300",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|7049|7|80|24022021",
+                  "prodX": 4,
+                  "dirTxt": "Liers",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 2,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "144600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "144600",
+                      "dTimeR": "144700",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Liers",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 14,
+                      "idx": 3,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "145200",
+                      "aTimeR": "145300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "145200",
+                      "dTimeR": "145300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 15,
+                      "idx": 4,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "145600",
+                      "aTimeR": "145700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "145700",
+                      "dTimeR": "145800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 16,
+                      "idx": 5,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "150100",
+                      "aTimeR": "150200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "150100",
+                      "dTimeR": "150200",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 17,
+                      "idx": 6,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "150500",
+                      "aTimeR": "150500",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "150500",
+                      "dTimeR": "150500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 18,
+                      "idx": 7,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "151000",
+                      "aTimeR": "151000",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "151000",
+                      "dTimeR": "151000",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 19,
+                      "idx": 8,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "151400",
+                      "aTimeR": "151400",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "151500",
+                      "dTimeR": "151500",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 20,
+                      "idx": 9,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "151900",
+                      "aTimeR": "152100",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "151900",
+                      "dTimeR": "152100",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 21,
+                      "idx": 10,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "152300",
+                      "aTimeR": "152400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "152300",
+                      "dTimeR": "152400",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 22,
+                      "idx": 11,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "152500",
+                      "aTimeR": "152500",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "152500",
+                      "dTimeR": "152500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 23,
+                      "idx": 12,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "152700",
+                      "aTimeR": "152700",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "152700",
+                      "dTimeR": "152800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 24,
+                      "idx": 13,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "153100",
+                      "aTimeR": "153200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "153100",
+                      "dTimeR": "153200",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 25,
+                      "idx": 14,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "153800",
+                      "aTimeR": "153800",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "153900",
+                      "dTimeR": "153900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 13,
+                      "idx": 15,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "154300",
+                      "aTimeR": "154300",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "154800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 13
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241446$202102241543$L   5586$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 6,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 13,
+                  "dPlatfS": "9",
+                  "dTimeS": "154300"
+                },
+                "arr": {
+                  "locX": 13,
+                  "aPlatfS": "7",
+                  "aTimeS": "154300"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 13,
+                  "idx": 2,
+                  "dProdX": 5,
+                  "dPlatfS": "7",
+                  "dInR": true,
+                  "dTimeS": "161000",
+                  "dTimeR": "161000",
+                  "dProgType": "REPORTED",
+                  "type": "N",
+                  "dTimeSCh": true
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 13,
+                  "aProdX": 5,
+                  "aPlatfS": "2",
+                  "aOutR": true,
+                  "aTimeS": "161000",
+                  "aTimeR": "161100",
+                  "aProgType": "REPORTED",
+                  "type": "N",
+                  "aTimeSCh": true
+                },
+                "jny": {
+                  "jid": "1|91397|0|80|24022021",
+                  "prodX": 5,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "ctxRecon": "T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241610$202102241610$IC  2437$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 7,
+                      "fLocX": 13,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241446$202102241543$L   5586$$1$§T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241610$202102241610$IC  2437$$3$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "123f050b_3",
+            "cksumDti": "d0504d44_3"
+          },
+          {
+            "cid": "C-3",
+            "date": "20210224",
+            "dur": "015900",
+            "chg": 1,
+            "sDays": {
+              "sDaysR": "pas toujours",
+              "sDaysI": "24. Fév jusq'au 2. Avr 2021 Lu - Ve",
+              "sDaysB": "7CF1E3E7CF9F3E7CF9F3E7CF9F3E0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 2,
+              "dProdX": 4,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "144600",
+              "dTimeR": "144700",
+              "dProgType": "REPORTED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 14,
+              "aProdX": 6,
+              "aPlatfS": "2",
+              "aOutR": true,
+              "aTimeS": "164500",
+              "aTimeR": "164500",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 2,
+                  "dProdX": 4,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "144600",
+                  "dTimeR": "144700",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 13,
+                  "idx": 15,
+                  "aProdX": 4,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "154300",
+                  "aTimeR": "154300",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|7049|7|80|24022021",
+                  "prodX": 4,
+                  "dirTxt": "Liers",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 2,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "144600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "144600",
+                      "dTimeR": "144700",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Liers",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 14,
+                      "idx": 3,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "145200",
+                      "aTimeR": "145300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "145200",
+                      "dTimeR": "145300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 15,
+                      "idx": 4,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "145600",
+                      "aTimeR": "145700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "145700",
+                      "dTimeR": "145800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 16,
+                      "idx": 5,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "150100",
+                      "aTimeR": "150200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "150100",
+                      "dTimeR": "150200",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 17,
+                      "idx": 6,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "150500",
+                      "aTimeR": "150500",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "150500",
+                      "dTimeR": "150500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 18,
+                      "idx": 7,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "151000",
+                      "aTimeR": "151000",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "151000",
+                      "dTimeR": "151000",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 19,
+                      "idx": 8,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "151400",
+                      "aTimeR": "151400",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "151500",
+                      "dTimeR": "151500",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 20,
+                      "idx": 9,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "151900",
+                      "aTimeR": "152100",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "151900",
+                      "dTimeR": "152100",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 21,
+                      "idx": 10,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "152300",
+                      "aTimeR": "152400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "152300",
+                      "dTimeR": "152400",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 22,
+                      "idx": 11,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "152500",
+                      "aTimeR": "152500",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "152500",
+                      "dTimeR": "152500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 23,
+                      "idx": 12,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "152700",
+                      "aTimeR": "152700",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "152700",
+                      "dTimeR": "152800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 24,
+                      "idx": 13,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "153100",
+                      "aTimeR": "153200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "153100",
+                      "dTimeR": "153200",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 25,
+                      "idx": 14,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "153800",
+                      "aTimeR": "153800",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 4,
+                      "dInR": true,
+                      "dTimeS": "153900",
+                      "dTimeR": "153900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 13,
+                      "idx": 15,
+                      "aProdX": 4,
+                      "aOutR": true,
+                      "aTimeS": "154300",
+                      "aTimeR": "154300",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "154800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 13
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241446$202102241543$L   5586$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 8,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 13,
+                  "dPlatfS": "9",
+                  "dTimeS": "154300"
+                },
+                "arr": {
+                  "locX": 13,
+                  "aPlatfS": "9",
+                  "aTimeS": "154300"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 13,
+                  "idx": 3,
+                  "dProdX": 6,
+                  "dPlatfS": "9",
+                  "dInR": true,
+                  "dTimeS": "162300",
+                  "dTimeR": "162400",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 14,
+                  "aProdX": 6,
+                  "aPlatfS": "2",
+                  "aOutR": true,
+                  "aTimeS": "164500",
+                  "aTimeR": "164500",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|5500|0|80|24022021",
+                  "prodX": 6,
+                  "dirTxt": "Mons",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 13,
+                      "idx": 3,
+                      "aProdX": 6,
+                      "aOutR": true,
+                      "aTimeS": "162100",
+                      "aProgType": "REPORTED",
+                      "dProdX": 6,
+                      "dInR": true,
+                      "dTimeS": "162300",
+                      "dTimeR": "162400",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Mons",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 26,
+                      "idx": 9,
+                      "aProdX": 6,
+                      "aOutR": true,
+                      "aTimeS": "163200",
+                      "aTimeR": "163200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 6,
+                      "dInR": true,
+                      "dTimeS": "163300",
+                      "dTimeR": "163400",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 14,
+                      "aProdX": 6,
+                      "aOutR": true,
+                      "aTimeS": "164500",
+                      "aTimeR": "164500",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "164600",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241623$202102241645$IC  3838$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 9,
+                      "fLocX": 13,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241446$202102241543$L   5586$$1$§T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241623$202102241645$IC  3838$$1$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "3d43a20e_3",
+            "cksumDti": "e0663d47_3"
+          },
+          {
+            "cid": "C-4",
+            "date": "20210224",
+            "dur": "013300",
+            "chg": 2,
+            "sDays": {
+              "sDaysR": "pas toujours",
+              "sDaysI": "24. Fév jusq'au 2. Avr 2021 Lu - Ve",
+              "sDaysB": "0000000000003E7C01F3E7CF9F3E0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "isNotRdbl": true,
+            "badSecRefX": 4,
+            "dep": {
+              "locX": 0,
+              "idx": 18,
+              "dProdX": 7,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "151100",
+              "dTimeR": "151600",
+              "dProgType": "REPORTED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 34,
+              "aProdX": 8,
+              "aPlatfS": "3",
+              "aOutR": true,
+              "aTimeS": "164400",
+              "aTimeR": "164400",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 18,
+                  "dProdX": 7,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "151100",
+                  "dTimeR": "151600",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 2,
+                  "idx": 20,
+                  "aProdX": 7,
+                  "aPlatfS": "1",
+                  "aOutR": true,
+                  "aTimeS": "152300",
+                  "aTimeR": "152600",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6994|7|80|24022021",
+                  "prodX": 7,
+                  "dirTxt": "Marloie",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 18,
+                      "aProdX": 7,
+                      "aOutR": true,
+                      "aTimeS": "151000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 7,
+                      "dInR": true,
+                      "dTimeS": "151100",
+                      "dTimeR": "151600",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Marloie",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 3,
+                      "idx": 19,
+                      "aProdX": 7,
+                      "aOutR": true,
+                      "aTimeS": "151800",
+                      "aTimeR": "152200",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 7,
+                      "dInR": true,
+                      "dTimeS": "151900",
+                      "dTimeR": "152200",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 2,
+                      "idx": 20,
+                      "aProdX": 7,
+                      "aOutR": true,
+                      "aTimeS": "152300",
+                      "aTimeR": "152600",
+                      "aProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 0,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241511$202102241523$L   5563$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 10,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 2,
+                  "dPlatfS": "1",
+                  "dTimeS": "152600"
+                },
+                "arr": {
+                  "locX": 2,
+                  "aPlatfS": "3",
+                  "aTimeS": "152600"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 2,
+                  "idx": 13,
+                  "dProdX": 9,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "153700",
+                  "dTimeR": "154600",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 4,
+                  "idx": 26,
+                  "aProdX": 9,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "161300",
+                  "aTimeR": "161800",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|2633|0|80|24022021",
+                  "prodX": 9,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 2,
+                      "idx": 13,
+                      "aProdX": 9,
+                      "aOutR": true,
+                      "aTimeS": "153600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 9,
+                      "dInR": true,
+                      "dTimeS": "153700",
+                      "dTimeR": "154600",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 5,
+                      "idx": 18,
+                      "aProdX": 9,
+                      "aOutR": true,
+                      "aTimeS": "155100",
+                      "aTimeR": "160000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 9,
+                      "dInR": true,
+                      "dTimeS": "155200",
+                      "dTimeR": "160300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 4,
+                      "idx": 26,
+                      "aProdX": 9,
+                      "aOutR": true,
+                      "aTimeS": "161300",
+                      "aTimeR": "161800",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "161700",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241537$202102241613$IC  2137$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 11,
+                      "fLocX": 2,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    },
+                    {
+                      "type": "REM",
+                      "remX": 1,
+                      "tagL": [
+                        "RES_SEC_HDR_H3"
+                      ],
+                      "persist": false
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 4,
+                  "dPlatfS": "9",
+                  "dTimeS": "161800"
+                },
+                "arr": {
+                  "locX": 4,
+                  "aPlatfS": "11",
+                  "aTimeS": "161800"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 4,
+                  "idx": 26,
+                  "dProdX": 8,
+                  "dPlatfS": "11",
+                  "dInR": true,
+                  "dTimeS": "161800",
+                  "dTimeR": "161900",
+                  "dProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 34,
+                  "aProdX": 8,
+                  "aPlatfS": "3",
+                  "aOutR": true,
+                  "aTimeS": "164400",
+                  "aTimeR": "164400",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|3164|0|80|24022021",
+                  "prodX": 8,
+                  "dirTxt": "Liège-Saint-Lambert",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": false,
+                  "stopL": [
+                    {
+                      "locX": 4,
+                      "idx": 26,
+                      "aProdX": 8,
+                      "aOutR": true,
+                      "aTimeS": "161600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 8,
+                      "dInR": true,
+                      "dTimeS": "161800",
+                      "dTimeR": "161900",
+                      "dProgType": "PROGNOSED",
+                      "dDirTxt": "Liège-Saint-Lambert",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 6,
+                      "idx": 31,
+                      "aProdX": 8,
+                      "aOutR": true,
+                      "aTimeS": "163100",
+                      "aTimeR": "163200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 8,
+                      "dInR": true,
+                      "dTimeS": "163200",
+                      "dTimeR": "163300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 7,
+                      "idx": 33,
+                      "aProdX": 8,
+                      "aOutR": true,
+                      "aTimeS": "164000",
+                      "aTimeR": "164000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 8,
+                      "dInR": true,
+                      "dTimeS": "164100",
+                      "dTimeR": "164100",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 34,
+                      "aProdX": 8,
+                      "aOutR": true,
+                      "aTimeS": "164400",
+                      "aTimeR": "164400",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "164500",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 3
+                  },
+                  "ctxRecon": "T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241618$202102241644$IC  2415$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 12,
+                      "fLocX": 4,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241511$202102241523$L   5563$$1$§T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241537$202102241613$IC  2137$$3$§T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241618$202102241644$IC  2415$$3$",
+            "msgL": [
+              {
+                "type": "REM",
+                "remX": 0,
+                "tagL": [
+                  "SUM_CON_HDR_H3",
+                  "RES_CON_HDR_H3"
+                ],
+                "persist": false
+              },
+              {
+                "type": "REM",
+                "remX": 2,
+                "txtC": {
+                  "r": 255,
+                  "g": 0,
+                  "b": 0
+                },
+                "tagL": [
+                  "SUM_CON_HDR",
+                  "RES_CON_FTR"
+                ]
+              }
+            ],
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "7453b8c1_3",
+            "cksumDti": "9d3b032d_3"
+          },
+          {
+            "cid": "C-5",
+            "date": "20210224",
+            "dur": "015000",
+            "chg": 2,
+            "sDays": {
+              "sDaysR": "Lu - Ve",
+              "sDaysI": "pas 5. Avr, 13., 24. Mai, 21. Jul, 1., 11. Nov",
+              "sDaysB": "0000000000003E7CF9F3E7CF9F3E3CF9F3E7CE9F1E7CF9F3E7CF9F367CF9F3E7CF9F3E7CF9F3E7CF8F3A7CF9F3E0"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 18,
+              "dProdX": 7,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "151100",
+              "dTimeR": "151600",
+              "dProgType": "REPORTED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 8,
+              "aProdX": 10,
+              "aPlatfS": "3",
+              "aOutR": true,
+              "aTimeS": "170100",
+              "aTimeR": "170400",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 18,
+                  "dProdX": 7,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "151100",
+                  "dTimeR": "151600",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 2,
+                  "idx": 20,
+                  "aProdX": 7,
+                  "aPlatfS": "1",
+                  "aOutR": true,
+                  "aTimeS": "152300",
+                  "aTimeR": "152600",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6994|7|80|24022021",
+                  "prodX": 7,
+                  "dirTxt": "Marloie",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 18,
+                      "aProdX": 7,
+                      "aOutR": true,
+                      "aTimeS": "151000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 7,
+                      "dInR": true,
+                      "dTimeS": "151100",
+                      "dTimeR": "151600",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Marloie",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 3,
+                      "idx": 19,
+                      "aProdX": 7,
+                      "aOutR": true,
+                      "aTimeS": "151800",
+                      "aTimeR": "152200",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 7,
+                      "dInR": true,
+                      "dTimeS": "151900",
+                      "dTimeR": "152200",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 2,
+                      "idx": 20,
+                      "aProdX": 7,
+                      "aOutR": true,
+                      "aTimeS": "152300",
+                      "aTimeR": "152600",
+                      "aProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 0,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241511$202102241523$L   5563$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 13,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 2,
+                  "dPlatfS": "1",
+                  "dTimeS": "152600"
+                },
+                "arr": {
+                  "locX": 2,
+                  "aPlatfS": "3",
+                  "aTimeS": "152600"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 2,
+                  "idx": 13,
+                  "dProdX": 9,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "153700",
+                  "dTimeR": "154600",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 4,
+                  "idx": 26,
+                  "aProdX": 9,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "161300",
+                  "aTimeR": "161800",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|2633|0|80|24022021",
+                  "prodX": 9,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 2,
+                      "idx": 13,
+                      "aProdX": 9,
+                      "aOutR": true,
+                      "aTimeS": "153600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 9,
+                      "dInR": true,
+                      "dTimeS": "153700",
+                      "dTimeR": "154600",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 5,
+                      "idx": 18,
+                      "aProdX": 9,
+                      "aOutR": true,
+                      "aTimeS": "155100",
+                      "aTimeR": "160000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 9,
+                      "dInR": true,
+                      "dTimeS": "155200",
+                      "dTimeR": "160300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 4,
+                      "idx": 26,
+                      "aProdX": 9,
+                      "aOutR": true,
+                      "aTimeS": "161300",
+                      "aTimeR": "161800",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "161700",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241537$202102241613$IC  2137$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 14,
+                      "fLocX": 2,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 4,
+                  "dPlatfS": "9",
+                  "dTimeS": "161800"
+                },
+                "arr": {
+                  "locX": 4,
+                  "aPlatfS": "3",
+                  "aTimeS": "161800"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 4,
+                  "idx": 0,
+                  "dProdX": 10,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "162700",
+                  "dTimeR": "163200",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 8,
+                  "aProdX": 10,
+                  "aPlatfS": "3",
+                  "aOutR": true,
+                  "aTimeS": "170100",
+                  "aTimeR": "170400",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6615|0|80|24022021",
+                  "prodX": 10,
+                  "dirTxt": "Liège-Guillemins",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 4,
+                      "idx": 0,
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "162700",
+                      "dTimeR": "163200",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Liège-Guillemins",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 8,
+                      "idx": 1,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "163400",
+                      "aTimeR": "163900",
+                      "aProgType": "REPORTED",
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "163400",
+                      "dTimeR": "163900",
+                      "dProgType": "CORRECTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 9,
+                      "idx": 2,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "163700",
+                      "aTimeR": "164200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "163700",
+                      "dTimeR": "164300",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 10,
+                      "idx": 3,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "164100",
+                      "aTimeR": "164700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "164100",
+                      "dTimeR": "164700",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 11,
+                      "idx": 4,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "164500",
+                      "aTimeR": "165000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "164500",
+                      "dTimeR": "165000",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 6,
+                      "idx": 5,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "164700",
+                      "aTimeR": "165200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "164800",
+                      "dTimeR": "165200",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 12,
+                      "idx": 6,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "165500",
+                      "aTimeR": "165900",
+                      "aProgType": "REPORTED",
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "165500",
+                      "dTimeR": "165900",
+                      "dProgType": "CORRECTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 7,
+                      "idx": 7,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "165800",
+                      "aTimeR": "170100",
+                      "aProgType": "REPORTED",
+                      "dProdX": 10,
+                      "dInR": true,
+                      "dTimeS": "165900",
+                      "dTimeR": "170200",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 8,
+                      "aProdX": 10,
+                      "aOutR": true,
+                      "aTimeS": "170100",
+                      "aTimeR": "170400",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "170300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 8
+                  },
+                  "ctxRecon": "T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241627$202102241701$L   4966$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 15,
+                      "fLocX": 4,
+                      "tLocX": 4,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241511$202102241523$L   5563$$1$§T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241537$202102241613$IC  2137$$3$§T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241627$202102241701$L   4966$$1$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "d7564326_3",
+            "cksumDti": "e25f7bbd_3"
+          },
+          {
+            "cid": "C-6",
+            "date": "20210224",
+            "dur": "012600",
+            "chg": 1,
+            "sDays": {
+              "sDaysR": "pas toujours",
+              "sDaysI": "24. Fév jusq'au 2. Avr 2021 Lu - Ve",
+              "sDaysB": "0000000000003E7CF9F3E7CF9F3E0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 2,
+              "dProdX": 11,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "154600",
+              "dTimeR": "154700",
+              "dProgType": "REPORTED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 13,
+              "aProdX": 12,
+              "aPlatfS": "2",
+              "aOutR": true,
+              "aTimeS": "171200",
+              "aTimeR": "171200",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 2,
+                  "dProdX": 11,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "154600",
+                  "dTimeR": "154700",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 13,
+                  "idx": 15,
+                  "aProdX": 11,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "164300",
+                  "aTimeR": "164500",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|7049|8|80|24022021",
+                  "prodX": 11,
+                  "dirTxt": "Liers",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 2,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "154600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "154600",
+                      "dTimeR": "154700",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Liers",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 14,
+                      "idx": 3,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "155200",
+                      "aTimeR": "155300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "155200",
+                      "dTimeR": "155300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 15,
+                      "idx": 4,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "155600",
+                      "aTimeR": "155700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "155700",
+                      "dTimeR": "155800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 16,
+                      "idx": 5,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "160100",
+                      "aTimeR": "160200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "160100",
+                      "dTimeR": "160200",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 17,
+                      "idx": 6,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "160500",
+                      "aTimeR": "160500",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "160500",
+                      "dTimeR": "160500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 18,
+                      "idx": 7,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "161000",
+                      "aTimeR": "161000",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "161000",
+                      "dTimeR": "161000",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 19,
+                      "idx": 8,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "161400",
+                      "aTimeR": "161400",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "161500",
+                      "dTimeR": "161500",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 20,
+                      "idx": 9,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "161900",
+                      "aTimeR": "162100",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "161900",
+                      "dTimeR": "162100",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 21,
+                      "idx": 10,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "162300",
+                      "aTimeR": "162500",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "162300",
+                      "dTimeR": "162500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 22,
+                      "idx": 11,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "162500",
+                      "aTimeR": "162600",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "162500",
+                      "dTimeR": "162600",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 23,
+                      "idx": 12,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "162700",
+                      "aTimeR": "162900",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "162700",
+                      "dTimeR": "162900",
+                      "dProgType": "CORRECTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 24,
+                      "idx": 13,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "163100",
+                      "aTimeR": "163300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "163100",
+                      "dTimeR": "163300",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 25,
+                      "idx": 14,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "163800",
+                      "aTimeR": "163800",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 11,
+                      "dInR": true,
+                      "dTimeS": "163900",
+                      "dTimeR": "164100",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 13,
+                      "idx": 15,
+                      "aProdX": 11,
+                      "aOutR": true,
+                      "aTimeS": "164300",
+                      "aTimeR": "164500",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "164800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 13
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241546$202102241643$L   5587$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 16,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 13,
+                  "dPlatfS": "9",
+                  "dTimeS": "164500"
+                },
+                "arr": {
+                  "locX": 13,
+                  "aPlatfS": "7",
+                  "aTimeS": "164500"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 13,
+                  "idx": 2,
+                  "dProdX": 12,
+                  "dPlatfS": "7",
+                  "dInR": true,
+                  "dTimeS": "165000",
+                  "dTimeR": "165100",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 13,
+                  "aProdX": 12,
+                  "aPlatfS": "2",
+                  "aOutR": true,
+                  "aTimeS": "171200",
+                  "aTimeR": "171200",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|3246|0|80|24022021",
+                  "prodX": 12,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 13,
+                      "idx": 2,
+                      "aProdX": 12,
+                      "aOutR": true,
+                      "aTimeS": "164700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 12,
+                      "dInR": true,
+                      "dTimeS": "165000",
+                      "dTimeR": "165100",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 26,
+                      "idx": 8,
+                      "aProdX": 12,
+                      "aOutR": true,
+                      "aTimeS": "165900",
+                      "aTimeR": "165900",
+                      "aProgType": "REPORTED",
+                      "dProdX": 12,
+                      "dInR": true,
+                      "dTimeS": "170000",
+                      "dTimeR": "170000",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 13,
+                      "aProdX": 12,
+                      "aOutR": true,
+                      "aTimeS": "171200",
+                      "aTimeR": "171200",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "171300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241650$202102241712$IC  2438$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 17,
+                      "fLocX": 13,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241546$202102241643$L   5587$$1$§T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241650$202102241712$IC  2438$$3$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "fb6bd2ec_3",
+            "cksumDti": "986e378c_3"
+          },
+          {
+            "cid": "C-7",
+            "date": "20210224",
+            "dur": "013300",
+            "chg": 2,
+            "sDays": {
+              "sDaysR": "pas toujours",
+              "sDaysI": "24. Fév",
+              "sDaysB": "00000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 18,
+              "dProdX": 13,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "161100",
+              "dTimeR": "161100",
+              "dProgType": "REPORTED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 34,
+              "aProdX": 14,
+              "aPlatfS": "3",
+              "aOutR": true,
+              "aTimeS": "174400",
+              "aTimeR": "174400",
+              "aProgType": "PROGNOSED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 18,
+                  "dProdX": 13,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "161100",
+                  "dTimeR": "161100",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 2,
+                  "idx": 20,
+                  "aProdX": 13,
+                  "aPlatfS": "1",
+                  "aOutR": true,
+                  "aTimeS": "162300",
+                  "aTimeR": "162300",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6994|8|80|24022021",
+                  "prodX": 13,
+                  "dirTxt": "Marloie",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 18,
+                      "aProdX": 13,
+                      "aOutR": true,
+                      "aTimeS": "161000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 13,
+                      "dInR": true,
+                      "dTimeS": "161100",
+                      "dTimeR": "161100",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Marloie",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 3,
+                      "idx": 19,
+                      "aProdX": 13,
+                      "aOutR": true,
+                      "aTimeS": "161800",
+                      "aTimeR": "161800",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 13,
+                      "dInR": true,
+                      "dTimeS": "161900",
+                      "dTimeR": "161900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 2,
+                      "idx": 20,
+                      "aProdX": 13,
+                      "aOutR": true,
+                      "aTimeS": "162300",
+                      "aTimeR": "162300",
+                      "aProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 0,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241611$202102241623$L   5564$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 18,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 2,
+                  "dPlatfS": "1",
+                  "dTimeS": "162300"
+                },
+                "arr": {
+                  "locX": 2,
+                  "aPlatfS": "3",
+                  "aTimeS": "162300"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 2,
+                  "idx": 13,
+                  "dProdX": 15,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "163900",
+                  "dTimeR": "163900",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 4,
+                  "idx": 26,
+                  "aProdX": 15,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "171400",
+                  "aTimeR": "171400",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|2649|0|80|24022021",
+                  "prodX": 15,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 2,
+                      "idx": 13,
+                      "aProdX": 15,
+                      "aOutR": true,
+                      "aTimeS": "163800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 15,
+                      "dInR": true,
+                      "dTimeS": "163900",
+                      "dTimeR": "163900",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 5,
+                      "idx": 18,
+                      "aProdX": 15,
+                      "aOutR": true,
+                      "aTimeS": "165400",
+                      "aTimeR": "165400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 15,
+                      "dInR": true,
+                      "dTimeS": "165600",
+                      "dTimeR": "165800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 4,
+                      "idx": 26,
+                      "aProdX": 15,
+                      "aOutR": true,
+                      "aTimeS": "171400",
+                      "aTimeR": "171400",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "171800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241639$202102241714$IC  2138$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 19,
+                      "fLocX": 2,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 4,
+                  "dPlatfS": "9",
+                  "dTimeS": "171400"
+                },
+                "arr": {
+                  "locX": 4,
+                  "aPlatfS": "11",
+                  "aTimeS": "171400"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 4,
+                  "idx": 26,
+                  "dProdX": 14,
+                  "dPlatfS": "11",
+                  "dInR": true,
+                  "dTimeS": "171800",
+                  "dTimeR": "171900",
+                  "dProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 34,
+                  "aProdX": 14,
+                  "aPlatfS": "3",
+                  "aOutR": true,
+                  "aTimeS": "174400",
+                  "aTimeR": "174400",
+                  "aProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|3167|0|80|24022021",
+                  "prodX": 14,
+                  "dirTxt": "Liège-Saint-Lambert",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 4,
+                      "idx": 26,
+                      "aProdX": 14,
+                      "aOutR": true,
+                      "aTimeS": "171600",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 14,
+                      "dInR": true,
+                      "dTimeS": "171800",
+                      "dTimeR": "171900",
+                      "dProgType": "PROGNOSED",
+                      "dDirTxt": "Liège-Saint-Lambert",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 6,
+                      "idx": 31,
+                      "aProdX": 14,
+                      "aOutR": true,
+                      "aTimeS": "173100",
+                      "aTimeR": "173300",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 14,
+                      "dInR": true,
+                      "dTimeS": "173200",
+                      "dTimeR": "173400",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 7,
+                      "idx": 33,
+                      "aProdX": 14,
+                      "aOutR": true,
+                      "aTimeS": "174000",
+                      "aTimeR": "174000",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 14,
+                      "dInR": true,
+                      "dTimeS": "174100",
+                      "dTimeR": "174100",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 34,
+                      "aProdX": 14,
+                      "aOutR": true,
+                      "aTimeS": "174400",
+                      "aTimeR": "174400",
+                      "aProgType": "PROGNOSED",
+                      "dInR": true,
+                      "dTimeS": "174500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": -1,
+                  "lPassStRT": {
+                    "idx": -1
+                  },
+                  "ctxRecon": "T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241718$202102241744$IC  2416$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 20,
+                      "fLocX": 4,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241611$202102241623$L   5564$$1$§T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241639$202102241714$IC  2138$$1$§T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241718$202102241744$IC  2416$$3$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "432ef780_3",
+            "cksumDti": "9e8bde03_3"
+          },
+          {
+            "cid": "C-8",
+            "date": "20210224",
+            "dur": "015000",
+            "chg": 2,
+            "sDays": {
+              "sDaysR": "Lu - Ve",
+              "sDaysI": "pas 5. Avr, 13., 24. Mai, 21. Jul, 1., 11. Nov",
+              "sDaysB": "0000000000003E7CF9F3E7CF9F3E3CF9F3E7CE9F1E7CF9F3E7CF9F367CF9F3E7CF9F3E7CF9F3E7CF8F3A7CF9F3E0"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 18,
+              "dProdX": 13,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "161100",
+              "dTimeR": "161100",
+              "dProgType": "REPORTED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 8,
+              "aProdX": 16,
+              "aPlatfS": "3",
+              "aOutR": true,
+              "aTimeS": "180100",
+              "aTimeR": "180100",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 18,
+                  "dProdX": 13,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "161100",
+                  "dTimeR": "161100",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 2,
+                  "idx": 20,
+                  "aProdX": 13,
+                  "aPlatfS": "1",
+                  "aOutR": true,
+                  "aTimeS": "162300",
+                  "aTimeR": "162300",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6994|8|80|24022021",
+                  "prodX": 13,
+                  "dirTxt": "Marloie",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 18,
+                      "aProdX": 13,
+                      "aOutR": true,
+                      "aTimeS": "161000",
+                      "aProgType": "REPORTED",
+                      "dProdX": 13,
+                      "dInR": true,
+                      "dTimeS": "161100",
+                      "dTimeR": "161100",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Marloie",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 3,
+                      "idx": 19,
+                      "aProdX": 13,
+                      "aOutR": true,
+                      "aTimeS": "161800",
+                      "aTimeR": "161800",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 13,
+                      "dInR": true,
+                      "dTimeS": "161900",
+                      "dTimeR": "161900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 2,
+                      "idx": 20,
+                      "aProdX": 13,
+                      "aOutR": true,
+                      "aTimeS": "162300",
+                      "aTimeR": "162300",
+                      "aProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 0,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241611$202102241623$L   5564$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 21,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 2,
+                  "dPlatfS": "1",
+                  "dTimeS": "162300"
+                },
+                "arr": {
+                  "locX": 2,
+                  "aPlatfS": "3",
+                  "aTimeS": "162300"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 2,
+                  "idx": 13,
+                  "dProdX": 15,
+                  "dPlatfS": "3",
+                  "dInR": true,
+                  "dTimeS": "163900",
+                  "dTimeR": "163900",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 4,
+                  "idx": 26,
+                  "aProdX": 15,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "171400",
+                  "aTimeR": "171400",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|2649|0|80|24022021",
+                  "prodX": 15,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 2,
+                      "idx": 13,
+                      "aProdX": 15,
+                      "aOutR": true,
+                      "aTimeS": "163800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 15,
+                      "dInR": true,
+                      "dTimeS": "163900",
+                      "dTimeR": "163900",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 5,
+                      "idx": 18,
+                      "aProdX": 15,
+                      "aOutR": true,
+                      "aTimeS": "165400",
+                      "aTimeR": "165400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 15,
+                      "dInR": true,
+                      "dTimeS": "165600",
+                      "dTimeR": "165800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 4,
+                      "idx": 26,
+                      "aProdX": 15,
+                      "aOutR": true,
+                      "aTimeS": "171400",
+                      "aTimeR": "171400",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "171800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241639$202102241714$IC  2138$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 22,
+                      "fLocX": 2,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 4,
+                  "dPlatfS": "9",
+                  "dTimeS": "171400"
+                },
+                "arr": {
+                  "locX": 4,
+                  "aPlatfS": "6",
+                  "aTimeS": "171400"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 4,
+                  "idx": 0,
+                  "dProdX": 16,
+                  "dPlatfS": "6",
+                  "dInR": true,
+                  "dTimeS": "172700",
+                  "dTimeR": "172800",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 8,
+                  "aProdX": 16,
+                  "aPlatfS": "3",
+                  "aOutR": true,
+                  "aTimeS": "180100",
+                  "aTimeR": "180100",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|6615|1|80|24022021",
+                  "prodX": 16,
+                  "dirTxt": "Liège-Guillemins",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 4,
+                      "idx": 0,
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "172700",
+                      "dTimeR": "172800",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Liège-Guillemins",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 8,
+                      "idx": 1,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "173400",
+                      "aTimeR": "173400",
+                      "aProgType": "REPORTED",
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "173400",
+                      "dTimeR": "173400",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 9,
+                      "idx": 2,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "173700",
+                      "aTimeR": "173800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "173700",
+                      "dTimeR": "173900",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 10,
+                      "idx": 3,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "174100",
+                      "aTimeR": "174300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "174100",
+                      "dTimeR": "174300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 11,
+                      "idx": 4,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "174500",
+                      "aTimeR": "174600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "174500",
+                      "dTimeR": "174600",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 6,
+                      "idx": 5,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "174700",
+                      "aTimeR": "174800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "174800",
+                      "dTimeR": "174900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 12,
+                      "idx": 6,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "175500",
+                      "aTimeR": "175600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "175500",
+                      "dTimeR": "175600",
+                      "dProgType": "CORRECTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 7,
+                      "idx": 7,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "175800",
+                      "aTimeR": "175800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 16,
+                      "dInR": true,
+                      "dTimeS": "175900",
+                      "dTimeR": "175900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 8,
+                      "aProdX": 16,
+                      "aOutR": true,
+                      "aTimeS": "180100",
+                      "aTimeR": "180100",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "180300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 8
+                  },
+                  "ctxRecon": "T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241727$202102241801$L   4967$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 23,
+                      "fLocX": 4,
+                      "tLocX": 4,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Marloie@L=8864345@a=128@$202102241611$202102241623$L   5564$$1$§T$A=1@O=Marloie@L=8864345@a=128@$A=1@O=Namur@L=8863008@a=128@$202102241639$202102241714$IC  2138$$1$§T$A=1@O=Namur@L=8863008@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241727$202102241801$L   4967$$1$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "5dd3a41e_3",
+            "cksumDti": "0239e052_3"
+          },
+          {
+            "cid": "C-9",
+            "date": "20210224",
+            "dur": "012600",
+            "chg": 1,
+            "sDays": {
+              "sDaysR": "pas toujours",
+              "sDaysI": "24. Fév jusq'au 2. Avr 2021 Lu - Ve",
+              "sDaysB": "0000000000003E7CF9F3E7CF9F3E0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "dep": {
+              "locX": 0,
+              "idx": 2,
+              "dProdX": 17,
+              "dPlatfS": "1",
+              "dInR": true,
+              "dTimeS": "164600",
+              "dTimeR": "164700",
+              "dProgType": "PROGNOSED",
+              "type": "N"
+            },
+            "arr": {
+              "locX": 1,
+              "idx": 13,
+              "aProdX": 18,
+              "aPlatfS": "2",
+              "aOutR": true,
+              "aTimeS": "181200",
+              "aTimeR": "181800",
+              "aProgType": "REPORTED",
+              "type": "N"
+            },
+            "secL": [
+              {
+                "type": "JNY",
+                "icoX": 1,
+                "dep": {
+                  "locX": 0,
+                  "idx": 2,
+                  "dProdX": 17,
+                  "dPlatfS": "1",
+                  "dInR": true,
+                  "dTimeS": "164600",
+                  "dTimeR": "164700",
+                  "dProgType": "PROGNOSED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 13,
+                  "idx": 15,
+                  "aProdX": 17,
+                  "aPlatfS": "9",
+                  "aOutR": true,
+                  "aTimeS": "174300",
+                  "aTimeR": "174300",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|7049|9|80|24022021",
+                  "prodX": 17,
+                  "dirTxt": "Liers",
+                  "status": "P",
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 0,
+                      "idx": 2,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "164600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "164600",
+                      "dTimeR": "164700",
+                      "dProgType": "PROGNOSED",
+                      "dDirTxt": "Liers",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 14,
+                      "idx": 3,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "165200",
+                      "aTimeR": "165300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "165200",
+                      "dTimeR": "165300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 15,
+                      "idx": 4,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "165600",
+                      "aTimeR": "165700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "165700",
+                      "dTimeR": "165700",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 16,
+                      "idx": 5,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "170100",
+                      "aTimeR": "170100",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "170100",
+                      "dTimeR": "170100",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 17,
+                      "idx": 6,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "170500",
+                      "aTimeR": "170500",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "170500",
+                      "dTimeR": "170500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 18,
+                      "idx": 7,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "171000",
+                      "aTimeR": "171000",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "171000",
+                      "dTimeR": "171000",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 19,
+                      "idx": 8,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "171400",
+                      "aTimeR": "171400",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "171500",
+                      "dTimeR": "171500",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 20,
+                      "idx": 9,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "171900",
+                      "aTimeR": "171900",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "171900",
+                      "dTimeR": "171900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 21,
+                      "idx": 10,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "172300",
+                      "aTimeR": "172300",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "172300",
+                      "dTimeR": "172300",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 22,
+                      "idx": 11,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "172500",
+                      "aTimeR": "172500",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "172500",
+                      "dTimeR": "172500",
+                      "dProgType": "PROGNOSED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 23,
+                      "idx": 12,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "172700",
+                      "aTimeR": "172800",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "172700",
+                      "dTimeR": "172800",
+                      "dProgType": "CORRECTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 24,
+                      "idx": 13,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "173100",
+                      "aTimeR": "173200",
+                      "aProgType": "REPORTED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "173100",
+                      "dTimeR": "173200",
+                      "dProgType": "CORRECTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 25,
+                      "idx": 14,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "173800",
+                      "aTimeR": "173800",
+                      "aProgType": "PROGNOSED",
+                      "dProdX": 17,
+                      "dInR": true,
+                      "dTimeS": "173900",
+                      "dTimeR": "173900",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 13,
+                      "idx": 15,
+                      "aProdX": 17,
+                      "aOutR": true,
+                      "aTimeS": "174300",
+                      "aTimeR": "174300",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "174800",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 13
+                  },
+                  "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241646$202102241743$L   5588$$1$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 24,
+                      "fLocX": 0,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "minChg": "000500",
+                "sty": "UNDEF"
+              },
+              {
+                "type": "WALK",
+                "icoX": 4,
+                "dep": {
+                  "locX": 13,
+                  "dPlatfS": "9",
+                  "dTimeS": "174300"
+                },
+                "arr": {
+                  "locX": 13,
+                  "aPlatfS": "5",
+                  "aTimeS": "174300"
+                },
+                "gis": {
+                  "dist": 0,
+                  "durS": "000000"
+                },
+                "sty": "UNDEF"
+              },
+              {
+                "type": "JNY",
+                "icoX": 3,
+                "dep": {
+                  "locX": 13,
+                  "idx": 2,
+                  "dProdX": 18,
+                  "dPlatfS": "5",
+                  "dInR": true,
+                  "dTimeS": "175000",
+                  "dTimeR": "175800",
+                  "dProgType": "REPORTED",
+                  "type": "N"
+                },
+                "arr": {
+                  "locX": 1,
+                  "idx": 13,
+                  "aProdX": 18,
+                  "aPlatfS": "2",
+                  "aOutR": true,
+                  "aTimeS": "181200",
+                  "aTimeR": "181800",
+                  "aProgType": "REPORTED",
+                  "type": "N"
+                },
+                "jny": {
+                  "jid": "1|3251|0|80|24022021",
+                  "prodX": 18,
+                  "dirTxt": "Bruxelles-Midi",
+                  "status": "P",
+                  "isRedir": true,
+                  "isRchbl": true,
+                  "stopL": [
+                    {
+                      "locX": 13,
+                      "idx": 2,
+                      "aProdX": 18,
+                      "aOutR": true,
+                      "aTimeS": "174700",
+                      "aProgType": "REPORTED",
+                      "dProdX": 18,
+                      "dInR": true,
+                      "dTimeS": "175000",
+                      "dTimeR": "175800",
+                      "dProgType": "REPORTED",
+                      "dDirTxt": "Bruxelles-Midi",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 26,
+                      "idx": 8,
+                      "aProdX": 18,
+                      "aOutR": true,
+                      "aTimeS": "175900",
+                      "aTimeR": "180600",
+                      "aProgType": "REPORTED",
+                      "dProdX": 18,
+                      "dInR": true,
+                      "dTimeS": "180000",
+                      "dTimeR": "180700",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    },
+                    {
+                      "locX": 1,
+                      "idx": 13,
+                      "aProdX": 18,
+                      "aOutR": true,
+                      "aTimeS": "181200",
+                      "aTimeR": "181800",
+                      "aProgType": "REPORTED",
+                      "dInR": true,
+                      "dTimeS": "181300",
+                      "dProgType": "REPORTED",
+                      "type": "N"
+                    }
+                  ],
+                  "procRT": 50,
+                  "lPassStRT": {
+                    "idx": 2
+                  },
+                  "ctxRecon": "T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241750$202102241812$IC  2439$$3$",
+                  "msgL": [
+                    {
+                      "type": "HIM",
+                      "himX": 25,
+                      "fLocX": 13,
+                      "tagL": [
+                        "SUM_GLB_HDR_H3",
+                        "RES_GLB_HDR_H3"
+                      ]
+                    }
+                  ],
+                  "subscr": "F"
+                },
+                "sty": "UNDEF"
+              }
+            ],
+            "ctxRecon": "T$A=1@O=Melreux-Hotton@L=8864436@a=128@$A=1@O=Liège-Guillemins@L=8841004@a=128@$202102241646$202102241743$L   5588$$1$§T$A=1@O=Liège-Guillemins@L=8841004@a=128@$A=1@O=Huy@L=8843307@a=128@$202102241750$202102241812$IC  2439$$3$",
+            "conSubscr": "U",
+            "recState": "U",
+            "cksum": "20e87874_3",
+            "cksumDti": "9fd66e11_3"
+          }
+        ],
+        "outCtxScrB": "1|OB|MT#23#108851#108851#108961#108961#0#0#285#108848#1#-2147483646#0#0#108848#-1#0#0#0#0#0#0#0#-2147483648#0#1#2|PDH#43d323259ab8289a4b1bd70c9f2bf2dc",
+        "outCtxScrF": "1|OF|MT#23#109006#109006#109092#109092#0#0#165#108972#6#-2147483646#0#0#108848#-1#0#0#0#0#0#0#0#-2147483648#0#1#2|PDH#43d323259ab8289a4b1bd70c9f2bf2dc",
+        "fpB": "20201213",
+        "fpE": "20211211",
+        "planrtTS": "1614197543",
+        "outConGrpL": [
+          {
+            "name": "???",
+            "icoX": 7,
+            "grpid": "cl_all",
+            "conScoringL": [
+              {
+                "type": "DT",
+                "conScoreL": [
+                  {
+                    "score": 8757306649831538685,
+                    "conRefL": [
+                      0
+                    ]
+                  },
+                  {
+                    "score": 8757306649795887101,
+                    "conRefL": [
+                      1
+                    ]
+                  },
+                  {
+                    "score": 8757148320176013310,
+                    "conRefL": [
+                      2
+                    ]
+                  },
+                  {
+                    "score": 8757148320102612990,
+                    "conRefL": [
+                      3
+                    ]
+                  },
+                  {
+                    "score": 8757020776808316925,
+                    "conRefL": [
+                      4
+                    ]
+                  },
+                  {
+                    "score": 8757020776772665341,
+                    "conRefL": [
+                      5
+                    ]
+                  },
+                  {
+                    "score": 8756884437381152766,
+                    "conRefL": [
+                      6
+                    ]
+                  },
+                  {
+                    "score": 8756778884250206205,
+                    "conRefL": [
+                      7
+                    ]
+                  },
+                  {
+                    "score": 8756778884214554621,
+                    "conRefL": [
+                      8
+                    ]
+                  },
+                  {
+                    "score": 8756620554590486526,
+                    "conRefL": [
+                      9
+                    ]
+                  }
+                ],
+                "name": "???"
+              },
+              {
+                "type": "AT",
+                "conScoreL": [
+                  {
+                    "score": 8756897631506006013,
+                    "conRefL": [
+                      0
+                    ]
+                  },
+                  {
+                    "score": 8756822864679665661,
+                    "conRefL": [
+                      1
+                    ]
+                  },
+                  {
+                    "score": 8756778884269080574,
+                    "conRefL": [
+                      2
+                    ]
+                  },
+                  {
+                    "score": 8756629350614302718,
+                    "conRefL": [
+                      3
+                    ]
+                  },
+                  {
+                    "score": 8756633748715339773,
+                    "conRefL": [
+                      4
+                    ]
+                  },
+                  {
+                    "score": 8756545787749466109,
+                    "conRefL": [
+                      5
+                    ]
+                  },
+                  {
+                    "score": 8756510603427708926,
+                    "conRefL": [
+                      6
+                    ]
+                  },
+                  {
+                    "score": 8756369865924673533,
+                    "conRefL": [
+                      7
+                    ]
+                  },
+                  {
+                    "score": 8756295099098333181,
+                    "conRefL": [
+                      8
+                    ]
+                  },
+                  {
+                    "score": 8756220332357976062,
+                    "conRefL": [
+                      9
+                    ]
+                  }
+                ],
+                "name": "???"
+              },
+              {
+                "type": "TI",
+                "conScoreL": [
+                  {
+                    "score": 9222962796291948541,
+                    "conRefL": [
+                      0
+                    ]
+                  },
+                  {
+                    "score": 9222888029501259773,
+                    "conRefL": [
+                      1
+                    ]
+                  },
+                  {
+                    "score": 9223002378635051006,
+                    "conRefL": [
+                      2
+                    ]
+                  },
+                  {
+                    "score": 9222848447007162366,
+                    "conRefL": [
+                      3
+                    ]
+                  },
+                  {
+                    "score": 9222962796155633661,
+                    "conRefL": [
+                      4
+                    ]
+                  },
+                  {
+                    "score": 9222888029364944893,
+                    "conRefL": [
+                      5
+                    ]
+                  },
+                  {
+                    "score": 9222993582416199678,
+                    "conRefL": [
+                      6
+                    ]
+                  },
+                  {
+                    "score": 9222962796040290301,
+                    "conRefL": [
+                      7
+                    ]
+                  },
+                  {
+                    "score": 9222888029249601533,
+                    "conRefL": [
+                      8
+                    ]
+                  },
+                  {
+                    "score": 9222993582290370558,
+                    "conRefL": [
+                      9
+                    ]
+                  }
+                ],
+                "name": "???"
+              }
+            ],
+            "initScoringType": "DT"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Fixes #434 
- Fixes empty arrays being printed as a `"empty":, ""` in json or `<empty/>` in xml. Now the array is printed exactly like a normal array, but without child elements. For example `<stops number="0"/>`