### PR TITLE
Fix subtype decoding for 4 carriages trains

### DIFF
--- a/src/api/data/NMBS/CompositionDataSource.php
+++ b/src/api/data/NMBS/CompositionDataSource.php
@@ -394,7 +394,7 @@ class CompositionDataSource
 
         // Trains with 4 carriages:
         if (in_array($materialType->parent_type, ['AM75'])) {
-            switch ($position % 3) {
+            switch ($position % 4) {
                 case 0:
                     $materialType->sub_type = "a";
                     break;


### PR DESCRIPTION
Hello 👋  
Reading source code, I realized this check was probably a copy-paste mistake as it didn't match the comment right above it.

I just discovered iRail after trying to use the realtime GTFS data of the SNCB/NMBS and missing the composition data. Thanks for the API and for making it open-source 🙏 