### PR TITLE
Fix Trainmap token parsing

### DIFF
--- a/src/api/data/NMBS/CompositionDataSource.php
+++ b/src/api/data/NMBS/CompositionDataSource.php
@@ -453,7 +453,7 @@ class CompositionDataSource
 
         // Search for localStorage.setItem('tmAuthCode', "6c088db73a11de02eebfc0e5e4d38c75");
 
-        preg_match("/localStorage\.setItem\(\"tmAuthCode\", \"(?<key>[A-Za-z0-9]+)\"\)/", $html, $matches);
+        preg_match("/localStorage\.setItem\(\"tmAuthCode\",\"(?<key>[A-Za-z0-9]+)\"\)/", $html, $matches);
         return $matches['key'];
     }
 }


### PR DESCRIPTION
The parsed HTML code from Trainmap does not contains a space after the comma anymore.

This commit and the previous one highlight the fragility of the token parsing method, that can break on any formatting update from Trainmap. A more long-lasting solution or a laxer regex may be needed.

Fixes #487