### PR TITLE
Fix #578, NullPointerException on liveboard entries missing required fields

### DIFF
--- a/src/main/java/be/irail/api/riv/NmbsRivLiveboardClient.java
+++ b/src/main/java/be/irail/api/riv/NmbsRivLiveboardClient.java
@@ -80,8 +80,12 @@ public class NmbsRivLiveboardClient {
     private DepartureOrArrival parseStopAtStation(LiveboardRequest request, StationDto currentStation, JsonNode entry) {
         boolean isArrivalBoard = request.timeSelection() == TimeSelection.ARRIVAL;
 
-        String plannedTimeStr = isArrivalBoard ? entry.get("PlannedArrival").asText() : entry.get("PlannedDeparture").asText();
-        LocalDateTime plannedDateTime = LocalDateTime.parse(plannedTimeStr, DATE_TIME_FORMATTER);
+        String plannedTimeKey = isArrivalBoard ? "PlannedArrival" : "PlannedDeparture";
+        if (!entry.hasNonNull(plannedTimeKey)) {
+            log.error("Liveboard entry without {}, skipping entry: {}", plannedTimeKey, entry);
+            return null;
+        }
+        LocalDateTime plannedDateTime = LocalDateTime.parse(entry.get(plannedTimeKey).asText(), DATE_TIME_FORMATTER);
         int delay = parseDelayInSeconds(entry, isArrivalBoard ? "ArrivalDelay" : "DepartureDelay");
 
         String platform = entry.has("Platform") ? entry.get("Platform").asText() : "?";
@@ -97,6 +101,10 @@ public class NmbsRivLiveboardClient {
             }
         }
 
+        if (!entry.hasNonNull("TrainNumber") || !entry.hasNonNull("CommercialType")) {
+            log.error("Liveboard entry without TrainNumber or CommercialType, skipping entry: {}", entry);
+            return null;
+        }
         int journeyNumber = entry.get("TrainNumber").asInt();
         String commercialType = entry.get("CommercialType").asText();
 


### PR DESCRIPTION
Fixes #578.

## The bug

`NmbsRivLiveboardClient.parseStopAtStation` reads the planned time like this:

```java
String plannedTimeStr = isArrivalBoard ? entry.get("PlannedArrival").asText()
                                       : entry.get("PlannedDeparture").asText();
```

`JsonNode.get()` returns `null` for a field that is not present, so `.asText()` on it throws a
bare `NullPointerException`. Nothing on the liveboard path catches it, so a single entry without
a planned time fails the **whole request** with a 500 — the station serves no departures at all
for as long as that entry stays in the requested window.

What made this stand out is that every other optional field in the same method is already
guarded:

```java
String platform      = entry.has("Platform") ? entry.get("Platform").asText() : "?";
boolean hasChanged   = entry.has("PlatformChanged") && ...;
boolean stopCanceled = entry.has("Status") && "Canceled".equals(...);
if (entry.has("DepartureStatusNl")) { ... }
```

The planned time is the first field read and the only unguarded one. `TrainNumber` and
`CommercialType` a few lines further down have the same problem. Note that `isServiceTrain()`
already tolerates a missing `CommercialType`, so entries without it do reach that line.

## The fix

Guard all three and skip the entry instead. `parseNmbsRawData` already discards `null` results
from this method, and the method already uses `log.error(...) + return null` for an unresolvable
direction station, so this follows the existing convention.

`hasNonNull()` is used rather than `has()` so an explicit JSON `null` is treated the same as an
absent field — `has()` would let a `NullNode` through to `asText()`, which returns the string
`"null"` and then fails in `LocalDateTime.parse` instead.

## Caveat on the diagnosis

I could not confirm *which* field the RIV API actually omits, because that API is
authenticated and I have no access to it. What I did observe from the outside is that
`/liveboard/` returned `500 NullPointerException` for a station for exactly as long as a
fully-cancelled train sat in its window, while `/vehicle/` and `/connections/` handled the same
train fine. Full write-up and timings in #578.

So: this hardens the parser against the failure shape that was observed. It may or may not be
the specific field involved. #2 in this series (isolating per-entry failures) is what actually
guarantees one bad entry cannot take down a board, regardless of which field it is.

---

**Disclosure:** I am an AI agent (Claude). This patch was written by reading the code and is
submitted from the account of the human who directed the work.

**This is untested.** I could not build or run it: the project targets Java 25 and only a
JDK 17 was available, with no Maven and no access to the RIV API or a database. The only
verification performed was a per-file `javac` parse, which surfaced no syntax or flow errors
(all remaining errors were unresolved-symbol errors, expected when compiling one file without
its classpath). Please review it as you would any untrusted patch.
