### PR TITLE
Isolate liveboard entry parse failures so one bad train cannot blank a station

### DIFF
--- a/src/main/java/be/irail/api/riv/NmbsRivLiveboardClient.java
+++ b/src/main/java/be/irail/api/riv/NmbsRivLiveboardClient.java
@@ -6,6 +6,7 @@ import be.irail.api.db.Station;
 import be.irail.api.db.StationsDao;
 import be.irail.api.dto.*;
 import be.irail.api.dto.result.LiveboardSearchResult;
+import be.irail.api.exception.IrailHttpException;
 import be.irail.api.exception.notfound.JourneyNotFoundException;
 import be.irail.api.exception.upstream.UpstreamServerException;
 import be.irail.api.gtfs.dao.GtfsInMemoryDao;
@@ -61,17 +62,36 @@ public class NmbsRivLiveboardClient {
         StationDto currentStation = convertToModelStation(dbStation, request.language());
 
         List<DepartureOrArrival> departuresOrArrivals = new ArrayList<>();
+        int failedEntries = 0;
         JsonNode entries = rawData.get("entries");
         if (entries != null && entries.isArray()) {
             for (JsonNode entry : entries) {
                 if (isServiceTrain(entry)) {
                     continue;
                 }
-                DepartureOrArrival parsedStop = parseStopAtStation(request, currentStation, entry);
-                if (parsedStop != null) {
-                    departuresOrArrivals.add(parsedStop);
+                try {
+                    DepartureOrArrival parsedStop = parseStopAtStation(request, currentStation, entry);
+                    if (parsedStop != null) {
+                        departuresOrArrivals.add(parsedStop);
+                    }
+                } catch (IrailHttpException e) {
+                    // A deliberate HTTP failure carries its own status code and message,
+                    // so it must not be downgraded into a skipped entry.
+                    throw e;
+                } catch (RuntimeException e) {
+                    // One unparseable entry should cost one departure, not the whole liveboard.
+                    failedEntries++;
+                    log.error("Failed to parse liveboard entry for station {}, skipping it: {}",
+                            request.station().getIrailId(), entry, e);
                 }
             }
+        }
+
+        // Losing every single entry is not a liveboard with no departures, it is a failure.
+        // Reporting it as such keeps a systemic problem visible instead of serving an empty board.
+        if (failedEntries > 0 && departuresOrArrivals.isEmpty()) {
+            throw new UpstreamServerException(
+                    "Failed to parse all " + failedEntries + " entries returned by the server.");
         }
 
         return new LiveboardSearchResult(currentStation, departuresOrArrivals);


### PR DESCRIPTION
Related to #578. Independent of the other PRs in this series — this one is about blast radius
rather than any single bug.

## The bug

`NmbsRivLiveboardClient.parseNmbsRawData` parses entries in a bare loop:

```java
for (JsonNode entry : entries) {
    if (isServiceTrain(entry)) continue;
    DepartureOrArrival parsedStop = parseStopAtStation(request, currentStation, entry);
    if (parsedStop != null) departuresOrArrivals.add(parsedStop);
}
```

There is no error handling around `parseStopAtStation`, so **any** unexpected
`RuntimeException` raised while parsing **one** entry propagates out and fails the entire
liveboard request. One malformed train means the station returns a 500 for every request until
that entry leaves the requested window — observed as tens of minutes at a time in #578.

That is a large blast radius for a per-entry problem, and it is the reason a single cancelled
long-distance train can blank out every station along its route in sequence.

## The fix

Catch unexpected runtime failures per entry, log the offending entry, and keep the remaining
departures.

Two deliberate details:

- **`IrailHttpException` is rethrown untouched.** Those carry an intentional status code and
  message (`StationsDao.getStationFromId` can raise `InternalProcessingException`, for example)
  and must not be silently downgraded into a skipped departure.

- **If every entry fails, the request still fails.** Returning an empty board in that case
  would turn a systemic problem into "this station has no trains", which is worse than a 500
  because it is indistinguishable from a quiet night. A board that is empty because there were
  genuinely no entries is unaffected.

The net effect: a broken entry costs one departure, a broken feed still surfaces as an error.

## Note

This is the change I would prioritise of the set. Even if the exact NPE in #578 turns out to be
something other than what the sibling PRs address, this one bounds the damage for the whole
class of parser bugs.

---

**Disclosure:** I am an AI agent (Claude). This patch was written by reading the code and is
submitted from the account of the human who directed the work.

**This is untested.** I could not build or run it: the project targets Java 25 and only a
JDK 17 was available, with no Maven and no access to the RIV API or a database. The only
verification performed was a per-file `javac` parse, which surfaced no syntax or flow errors
(all remaining errors were unresolved-symbol errors, expected when compiling one file without
its classpath). Please review it as you would any untrusted patch.
