### PR TITLE
Guard against an unknown vehicle direction in the V1 liveboard converter

### DIFF
--- a/src/main/java/be/irail/api/legacy/LiveboardV1Converter.java
+++ b/src/main/java/be/irail/api/legacy/LiveboardV1Converter.java
@@ -2,6 +2,7 @@ package be.irail.api.legacy;
 
 import be.irail.api.dto.DepartureArrivalState;
 import be.irail.api.dto.DepartureOrArrival;
+import be.irail.api.dto.StationDto;
 import be.irail.api.dto.TimeSelection;
 import be.irail.api.dto.result.LiveboardSearchResult;
 import be.irail.api.riv.requests.LiveboardRequest;
@@ -38,7 +39,7 @@ public class LiveboardV1Converter extends V1Converter {
 
     private static V1Departure convertDeparture(DepartureOrArrival departure) {
         V1Departure result = new V1Departure();
-        result.station = convertStation(departure.getVehicle().getDirection().getStation());
+        result.station = convertDirectionStation(departure);
         result.time = departure.getScheduledDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
         result.delay = departure.getDelay();
         result.canceled = departure.isCancelled() ? "1" : "0";
@@ -53,7 +54,7 @@ public class LiveboardV1Converter extends V1Converter {
 
     private static V1Arrival convertArrival(DepartureOrArrival arrival) {
         V1Arrival result = new V1Arrival();
-        result.station = convertStation(arrival.getVehicle().getDirection().getStation());
+        result.station = convertDirectionStation(arrival);
         result.time = arrival.getScheduledDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
         result.delay = arrival.getDelay();
         result.canceled = arrival.isCancelled() ? "1" : "0";
@@ -63,6 +64,21 @@ public class LiveboardV1Converter extends V1Converter {
         result.platform = convertPlatform(arrival.getPlatform());
         result.departureConnection = arrival.getDepartureUri();
         return result;
+    }
+
+    /**
+     * Converts the station a vehicle is heading to (or coming from), when it is known.
+     *
+     * @param departureOrArrival the departure or arrival to read the direction from
+     * @return the converted direction station, or null if the vehicle, its direction or the
+     *         direction's station is unknown
+     */
+    private static V1Station convertDirectionStation(DepartureOrArrival departureOrArrival) {
+        if (departureOrArrival.getVehicle() == null || departureOrArrival.getVehicle().getDirection() == null) {
+            return null;
+        }
+        StationDto station = departureOrArrival.getVehicle().getDirection().getStation();
+        return station != null ? convertStation(station) : null;
     }
 
     // Inner classes for V1 output structure


### PR DESCRIPTION
Related to #578.

## The bug

`LiveboardV1Converter` dereferences a three-deep chain with no null check, in both
`convertDeparture` and `convertArrival`:

```java
result.station = convertStation(departure.getVehicle().getDirection().getStation());
```

If the direction could not be resolved for a departure, this throws a `NullPointerException`
that fails the whole liveboard response — not just that one departure.

The sibling converter already guards the identical chain:

```java
// JourneyPlanningV1Converter.convertDirection
if (departureOrArrival.getVehicle() != null && departureOrArrival.getVehicle().getDirection() != null) {
    StationDto station = departureOrArrival.getVehicle().getDirection().getStation();
    result.name = station != null ? station.getLocalizedStationName() : ...;
}
```

This asymmetry is interesting in the context of #578: `/connections` kept working for the exact
train that was breaking `/liveboard`, and this is one of the places where the two paths differ
in robustness.

## The fix

Extract a small `convertDirectionStation` helper that applies the same guard as
`JourneyPlanningV1Converter`, and emit a `null` station for that departure instead of failing
the request.

Note `V1Converter.convertStation` dereferences its argument, so the helper returns early rather
than passing `null` into it.

## Trade-off worth flagging

This changes the V1 output shape in an edge case: a departure with an unresolvable direction
will now serialise with a null `station` instead of the request failing. If you would rather
drop such departures from the board entirely, that is a one-line change in the callers — say
the word and I will adjust. I picked "emit and degrade" because it matches what
`JourneyPlanningV1Converter` already does.

---

**Disclosure:** I am an AI agent (Claude). This patch was written by reading the code and is
submitted from the account of the human who directed the work.

**This is untested.** I could not build or run it: the project targets Java 25 and only a
JDK 17 was available, with no Maven and no access to the RIV API or a database. The only
verification performed was a per-file `javac` parse, which surfaced no syntax or flow errors
(all remaining errors were unresolved-symbol errors, expected when compiling one file without
its classpath). Please review it as you would any untrusted patch.
