### PR TITLE
Null-guard the DAO lookups in GtfsLiveboardClient

### DIFF
--- a/src/main/java/be/irail/api/gtfs/GtfsLiveboardClient.java
+++ b/src/main/java/be/irail/api/gtfs/GtfsLiveboardClient.java
@@ -11,6 +11,8 @@ import be.irail.api.gtfs.reader.models.GtfsRtUpdate;
 import be.irail.api.gtfs.reader.models.PickupDropoffType;
 import be.irail.api.gtfs.reader.models.Stop;
 import be.irail.api.riv.requests.LiveboardRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -23,6 +25,7 @@ import java.util.Map;
  */
 @Service
 public class GtfsLiveboardClient {
+    private static final Logger log = LogManager.getLogger(GtfsLiveboardClient.class);
 
     private final StationsDao stationsDao;
     private final OccupancyDao occupancyDao;
@@ -62,11 +65,21 @@ public class GtfsLiveboardClient {
             if (request.timeSelection() == TimeSelection.DEPARTURE) {
                 departureOrArrival.setScheduledDateTime(call.stopTime().getDepartureTime(call.startDate()));
                 Station destinationStation = stationsDao.getStationFromId(call.destinationParentStop().getHafasId());
+                if (destinationStation == null) {
+                    log.error("Unknown destination station {} for trip {}, skipping call",
+                            call.destinationParentStop().getHafasId(), call.trip().id());
+                    continue;
+                }
                 vehicle.setDirection(new VehicleDirection(call.trip().headsign(), destinationStation.toDto(request.language())));
                 departureOrArrival.setOccupancy(occupancyDao.getOccupancy(departureOrArrival));
             } else {
                 departureOrArrival.setScheduledDateTime(call.stopTime().getArrivalTime(call.startDate()));
                 Station originStation = stationsDao.getStationFromId(call.originParentStop().getHafasId());
+                if (originStation == null) {
+                    log.error("Unknown origin station {} for trip {}, skipping call",
+                            call.originParentStop().getHafasId(), call.trip().id());
+                    continue;
+                }
                 vehicle.setDirection(new VehicleDirection(originStation.getName(request.language()), originStation.toDto(request.language())));
             }
 
@@ -80,9 +93,10 @@ public class GtfsLiveboardClient {
                 }
 
                 departureOrArrival.setIsCancelled(rtUpdate.cancelled());
-                String newPlatform = staticDao.getStop(rtUpdate.stopId()).platformCode();
                 if (!rtUpdate.stopId().equals(platform.id())) {
-                    departureOrArrival.setPlatform(new PlatformInfo(rtUpdate.parentStopId(), newPlatform, true));
+                    Stop newPlatform = staticDao.getStop(rtUpdate.stopId());
+                    departureOrArrival.setPlatform(new PlatformInfo(rtUpdate.parentStopId(),
+                            newPlatform != null ? newPlatform.platformCode() : null, true));
                 }
             }
             results.add(departureOrArrival);


### PR DESCRIPTION
Found while investigating #578. **`GtfsLiveboardClient` currently has no callers** —
`LiveboardV1Controller` injects `NmbsRivLiveboardClient` — so this is latent rather than
something users are hitting today. Worth fixing before it is wired up.

## The bug

Three lookups in `getLiveboard` are dereferenced without a null check, and both DAOs return
`null` for an unknown key by construction:

```java
// StationsDao.getStationFromId ends in .orElse(null)
Station destinationStation = stationsDao.getStationFromId(call.destinationParentStop().getHafasId());
vehicle.setDirection(new VehicleDirection(..., destinationStation.toDto(request.language())));   // NPE

Station originStation = stationsDao.getStationFromId(call.originParentStop().getHafasId());
vehicle.setDirection(new VehicleDirection(originStation.getName(...), ...));                     // NPE

// GtfsInMemoryDao.getStop is a plain `stops.get(stopId)`
String newPlatform = staticDao.getStop(rtUpdate.stopId()).platformCode();                        // NPE
```

The last one is the most likely to bite in practice. It only runs for calls that **have a
realtime update**, and a realtime feed can legitimately reference a stop that the currently
loaded static feed does not know about yet — for instance while the static feed is a day or two
behind the realtime one.

## The fix

- Skip calls whose direction station cannot be resolved, logging the unresolved id and trip.
  This matches how `NmbsRivLiveboardClient` already handles an unknown direction station.
- Fall back to an unknown platform designation when the new platform stop is missing.
  `PlatformInfo` already turns a `null` designation into `"?"`, so no other change is needed.
- Move the `getStop` lookup **inside** the branch that is its only consumer. It was previously
  performed for every realtime update whether or not the platform had actually changed, so this
  also removes a map lookup from the hot path.

A `Logger` field is added, matching `NmbsRivLiveboardClient`.

---

**Disclosure:** I am an AI agent (Claude). This patch was written by reading the code and is
submitted from the account of the human who directed the work.

**This is untested.** I could not build or run it: the project targets Java 25 and only a
JDK 17 was available, with no Maven and no access to the RIV API or a database. The only
verification performed was a per-file `javac` parse, which surfaced no syntax or flow errors
(all remaining errors were unresolved-symbol errors, expected when compiling one file without
its classpath). Please review it as you would any untrusted patch.
