### PR TITLE
Fix #574 proposal

### DIFF
--- a/src/main/java/be/irail/api/controllers/v1/DatedVehicleJourneyV1Controller.java
+++ b/src/main/java/be/irail/api/controllers/v1/DatedVehicleJourneyV1Controller.java
@@ -6,6 +6,7 @@ import be.irail.api.dto.result.VehicleJourneySearchResult;
 import be.irail.api.exception.InternalProcessingException;
 import be.irail.api.exception.IrailHttpException;
 import be.irail.api.exception.notfound.IrailNotFoundException;
+import be.irail.api.gtfs.GtfsVehicleJourneyClient;
 import be.irail.api.legacy.DataRoot;
 import be.irail.api.legacy.DatedVehicleJourneyV1Converter;
 import be.irail.api.riv.NmbsRivVehicleJourneyClient;
@@ -39,11 +40,16 @@ public class DatedVehicleJourneyV1Controller extends V1Controller {
 
     private static final Logger log = LoggerFactory.getLogger(DatedVehicleJourneyV1Controller.class);
 
-    private final NmbsRivVehicleJourneyClient vehicleJourneyClient;
+    private final NmbsRivVehicleJourneyClient rivVehicleJourneyClient;
+    private final GtfsVehicleJourneyClient gtfsVehicleJourneyClient;
 
     @Autowired
-    public DatedVehicleJourneyV1Controller(NmbsRivVehicleJourneyClient vehicleJourneyClient) {
-        this.vehicleJourneyClient = vehicleJourneyClient;
+    public DatedVehicleJourneyV1Controller(
+            NmbsRivVehicleJourneyClient rivVehicleJourneyClient,
+            GtfsVehicleJourneyClient gtfsVehicleJourneyClient
+    ) {
+        this.rivVehicleJourneyClient = rivVehicleJourneyClient;
+        this.gtfsVehicleJourneyClient = gtfsVehicleJourneyClient;
     }
 
     /**
@@ -82,7 +88,7 @@ public class DatedVehicleJourneyV1Controller extends V1Controller {
 
         try {
             // Fetch vehicle journey data
-            VehicleJourneySearchResult vehicleJourneyResult = vehicleJourneyClient.getDatedVehicleJourney(request);
+            VehicleJourneySearchResult vehicleJourneyResult = getDatedVehicleJourney(request);
             log.debug("Found {} stops for vehicle {}", vehicleJourneyResult.getStops().size(), id);
 
             // Convert to V1 format
@@ -104,6 +110,17 @@ public class DatedVehicleJourneyV1Controller extends V1Controller {
             }
             throw new InternalProcessingException("Error fetching vehicle journey", exception);
         }
+    }
+
+    VehicleJourneySearchResult getDatedVehicleJourney(VehicleJourneyRequest request) throws ExecutionException {
+        if (usesGtfs(request.dateTime().toLocalDate(), LocalDate.now())) {
+            return gtfsVehicleJourneyClient.getDatedVehicleJourney(request);
+        }
+        return rivVehicleJourneyClient.getDatedVehicleJourney(request);
+    }
+
+    static boolean usesGtfs(LocalDate requestedDate, LocalDate currentDate) {
+        return !requestedDate.equals(currentDate);
     }
 
     /**

--- a/src/main/java/be/irail/api/riv/NmbsRivVehicleJourneyClient.java
+++ b/src/main/java/be/irail/api/riv/NmbsRivVehicleJourneyClient.java
@@ -65,7 +65,7 @@ public class NmbsRivVehicleJourneyClient extends RivClient {
         // Extract start date from ref or use request date
         String ref = json.get("ref").asText();
         LocalDate journeyStartDate = extractStartDate(ref);
-        journeyStartDate = Objects.requireNonNullElse(journeyStartDate, LocalDate.now());
+        journeyStartDate = Objects.requireNonNullElse(journeyStartDate, request.dateTime().toLocalDate());
 
         Vehicle vehicle = Vehicle.fromTypeAndNumber(trainType, trainNumber, journeyStartDate);
         setDirection(vehicle, json, request.language());

--- a/src/test/java/be/irail/api/controllers/v1/DatedVehicleJourneyV1ControllerTest.java
+++ b/src/test/java/be/irail/api/controllers/v1/DatedVehicleJourneyV1ControllerTest.java
@@ -1,0 +1,28 @@
+package be.irail.api.controllers.v1;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatedVehicleJourneyV1ControllerTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 20);
+
+    @Test
+    void usesRivForCurrentDate() {
+        assertFalse(DatedVehicleJourneyV1Controller.usesGtfs(TODAY, TODAY));
+    }
+
+    @Test
+    void usesGtfsForPastDate() {
+        assertTrue(DatedVehicleJourneyV1Controller.usesGtfs(TODAY.minusDays(1), TODAY));
+    }
+
+    @Test
+    void usesGtfsForFutureDate() {
+        assertTrue(DatedVehicleJourneyV1Controller.usesGtfs(TODAY.plusDays(1), TODAY));
+    }
+}


### PR DESCRIPTION
 * /v1/vehicle now uses RIV for today’s journey.
 * Past and future dates use the GTFS vehicle client, which respects the requested date.
 * If a RIV response lacks a journey date, it now falls back to the requested date instead of `LocalDate.now()`.

Fixes #574 
