### PR TITLE
Load IrailJavaApplicationTests against the H2 test profile so the suite runs without Postgres

### DIFF
--- a/src/test/java/be/irail/api/IrailJavaApplicationTests.java
+++ b/src/test/java/be/irail/api/IrailJavaApplicationTests.java
@@ -2,8 +2,10 @@ package be.irail.api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class IrailJavaApplicationTests {
 
     @Test


### PR DESCRIPTION
IrailJavaApplicationTests is the stock @SpringBootTest context test. Without @ActiveProfiles("test") it boots the full context against the default datasource from application.properties (PostgreSQL on localhost:54320). When no Postgres is available, contextLoads fails to initialise the ApplicationContext (Liquibase cannot connect), and because the failed context is cached, every other @SpringBootTest in the suite errors off it too.

Adding @ActiveProfiles("test") makes it use the in-memory H2 configuration in application-test.properties, so the full suite runs without an external database.

Before: Tests run: 8, Errors: 1 (contextLoads: Connection to localhost:54320 refused).
After: Tests run: 15, Failures: 0, Errors: 0.

Test-only change; no runtime code affected.