### PR TITLE
Send an auth header on GTFS-RT fetches, poll every 30s, and back off on quota errors

### DIFF
--- a/src/main/java/be/irail/api/gtfs/reader/GtfsRtReader.java
+++ b/src/main/java/be/irail/api/gtfs/reader/GtfsRtReader.java
@@ -7,43 +7,108 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
-import java.net.URL;
-
-import org.slf4j.LoggerFactory;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
 
 /**
  * Service for reading GTFS-Realtime data from a remote source.
- * This class handles the retrieval and parsing of TripUpdates in protobuf format.
- * The source URL is configurable via application properties or environment variables.
+ * Handles retrieval and parsing of TripUpdates in protobuf format. The source URL and,
+ * when the upstream requires it, an API key header are configurable via application
+ * properties or environment variables. Belgian Mobility (an Azure API Management gateway)
+ * returns "403 Quota Exceeded" for unauthenticated or over-quota callers; on a 403 or 429
+ * the reader honours Retry-After and backs off instead of hammering the endpoint.
  */
 @Service
 public class GtfsRtReader {
 
     private static final Logger log = LogManager.getLogger(GtfsRtReader.class);
 
+    /** Fallback back-off when the upstream throttles without a Retry-After header. */
+    private static final long DEFAULT_COOLDOWN_SECONDS = 300;
+
     @Value("${gtfs.rt.url:https://sncb-opendata.hafas.de/gtfs/realtime/d22ad6759ee25bg84ddb6c818g4dc4de_TC}")
     private String gtfsRtUrl;
+
+    /** Optional API key sent with each request; empty means unauthenticated (e.g. the hafas feed). */
+    @Value("${gtfs.rt.apiKey:}")
+    private String apiKey;
+
+    /** Header the API key is sent in. Belgian Mobility uses bmc-partner-key; Azure APIM's generic default is Ocp-Apim-Subscription-Key. */
+    @Value("${gtfs.rt.apiKeyHeader:bmc-partner-key}")
+    private String apiKeyHeader;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    /** When throttled, do not fetch again before this instant. */
+    private volatile Instant cooldownUntil;
 
     /**
      * Fetches and parses the latest TripUpdates from the configured GTFS-Realtime endpoint.
      *
-     * @return the parsed FeedMessage containing TripUpdates, or null if an error occurred
+     * @return the parsed FeedMessage, or null if in cooldown, throttled, or an error occurred
      */
     public FeedMessage readTripUpdates() {
+        Instant until = cooldownUntil;
+        if (until != null && Instant.now().isBefore(until)) {
+            log.debug("GTFS-RT feed in cooldown until {}, skipping fetch", until);
+            return null;
+        }
+
+        HttpRequest.Builder request = HttpRequest.newBuilder()
+                .uri(URI.create(gtfsRtUrl))
+                .timeout(Duration.ofSeconds(20))
+                .header("User-Agent", "iRail/gtfs-rt (+https://api.irail.be)")
+                .GET();
+        if (apiKey != null && !apiKey.isBlank()) {
+            request.header(apiKeyHeader, apiKey);
+        }
+
         log.info("Fetching GTFS-RT TripUpdates from {}", gtfsRtUrl);
         try {
-            URL url = URI.create(gtfsRtUrl).toURL();
-            try (InputStream inputStream = url.openStream()) {
-                return FeedMessage.parseFrom(inputStream);
+            HttpResponse<byte[]> response = httpClient.send(request.build(), HttpResponse.BodyHandlers.ofByteArray());
+            int status = response.statusCode();
+            if (status == 200) {
+                return FeedMessage.parseFrom(response.body());
             }
+            if (status == 403 || status == 429) {
+                startCooldown(response);
+                return null;
+            }
+            log.error("GTFS-RT feed at {} returned unexpected status {}", gtfsRtUrl, status);
+            return null;
         } catch (IOException e) {
-            log.error("Failed to read or parse GTFS-RT feed from " + gtfsRtUrl, e);
+            log.error("Failed to read or parse GTFS-RT feed from {}", gtfsRtUrl, e);
             return null;
-        } catch (IllegalArgumentException e) {
-            log.error("Invalid GTFS-RT URL: " + gtfsRtUrl, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Interrupted while fetching GTFS-RT feed from {}", gtfsRtUrl, e);
             return null;
+        }
+    }
+
+    /** Starts a back-off window, honouring Retry-After (delta-seconds) when present. */
+    private void startCooldown(HttpResponse<byte[]> response) {
+        long seconds = response.headers().firstValue("Retry-After")
+                .map(this::parseRetryAfterSeconds)
+                .orElse(DEFAULT_COOLDOWN_SECONDS);
+        cooldownUntil = Instant.now().plusSeconds(seconds);
+        log.warn("GTFS-RT feed at {} returned HTTP {} (quota/throttle); backing off {}s until {}",
+                gtfsRtUrl, response.statusCode(), seconds, cooldownUntil);
+    }
+
+    private long parseRetryAfterSeconds(String value) {
+        try {
+            return Math.max(0, Long.parseLong(value.trim()));
+        } catch (NumberFormatException e) {
+            // Retry-After may also be an HTTP-date; fall back rather than parse it precisely.
+            return DEFAULT_COOLDOWN_SECONDS;
         }
     }
 }

--- a/src/main/java/be/irail/api/gtfs/reader/GtfsRtReader.java
+++ b/src/main/java/be/irail/api/gtfs/reader/GtfsRtReader.java
@@ -28,7 +28,9 @@ public class GtfsRtReader {
     private static final Logger log = LogManager.getLogger(GtfsRtReader.class);
 
     /** Fallback back-off when the upstream throttles without a Retry-After header. */
-    private static final long DEFAULT_COOLDOWN_SECONDS = 300;
+    private static final long DEFAULT_BACKOFF_SECONDS = 300;
+
+    private static final String USER_AGENT = "iRail-gtfs-rt";
 
     @Value("${gtfs.rt.url:https://sncb-opendata.hafas.de/gtfs/realtime/d22ad6759ee25bg84ddb6c818g4dc4de_TC}")
     private String gtfsRtUrl;
@@ -47,60 +49,63 @@ public class GtfsRtReader {
             .build();
 
     /** When throttled, do not fetch again before this instant. */
-    private volatile Instant cooldownUntil;
+    private Instant backoffUntil;
 
     /**
      * Fetches and parses the latest TripUpdates from the configured GTFS-Realtime endpoint.
      *
-     * @return the parsed FeedMessage, or null if in cooldown, throttled, or an error occurred
+     * @return the parsed FeedMessage, or null while backing off, when throttled, or on an error
      */
     public FeedMessage readTripUpdates() {
-        Instant until = cooldownUntil;
-        if (until != null && Instant.now().isBefore(until)) {
-            log.debug("GTFS-RT feed in cooldown until {}, skipping fetch", until);
-            return null;
+        FeedMessage feed = null;
+        if (isBackingOff()) {
+            log.debug("GTFS-RT feed backing off until {}, skipping fetch", backoffUntil);
+        } else {
+            log.info("Fetching GTFS-RT TripUpdates from {}", gtfsRtUrl);
+            try {
+                HttpResponse<byte[]> response = httpClient.send(buildRequest(), HttpResponse.BodyHandlers.ofByteArray());
+                int status = response.statusCode();
+                if (status == 200) {
+                    feed = FeedMessage.parseFrom(response.body());
+                } else if (status == 403 || status == 429) {
+                    startBackoff(response);
+                } else {
+                    log.error("GTFS-RT feed at {} returned unexpected status {}", gtfsRtUrl, status);
+                }
+            } catch (IOException e) {
+                log.error("Failed to read or parse GTFS-RT feed from {}", gtfsRtUrl, e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted while fetching GTFS-RT feed from {}", gtfsRtUrl, e);
+            }
         }
+        return feed;
+    }
 
+    private boolean isBackingOff() {
+        return backoffUntil != null && Instant.now().isBefore(backoffUntil);
+    }
+
+    private HttpRequest buildRequest() {
         HttpRequest.Builder request = HttpRequest.newBuilder()
                 .uri(URI.create(gtfsRtUrl))
                 .timeout(Duration.ofSeconds(20))
-                .header("User-Agent", "iRail/gtfs-rt (+https://api.irail.be)")
+                .header("User-Agent", USER_AGENT)
                 .GET();
         if (apiKey != null && !apiKey.isBlank()) {
             request.header(apiKeyHeader, apiKey);
         }
-
-        log.info("Fetching GTFS-RT TripUpdates from {}", gtfsRtUrl);
-        try {
-            HttpResponse<byte[]> response = httpClient.send(request.build(), HttpResponse.BodyHandlers.ofByteArray());
-            int status = response.statusCode();
-            if (status == 200) {
-                return FeedMessage.parseFrom(response.body());
-            }
-            if (status == 403 || status == 429) {
-                startCooldown(response);
-                return null;
-            }
-            log.error("GTFS-RT feed at {} returned unexpected status {}", gtfsRtUrl, status);
-            return null;
-        } catch (IOException e) {
-            log.error("Failed to read or parse GTFS-RT feed from {}", gtfsRtUrl, e);
-            return null;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("Interrupted while fetching GTFS-RT feed from {}", gtfsRtUrl, e);
-            return null;
-        }
+        return request.build();
     }
 
     /** Starts a back-off window, honouring Retry-After (delta-seconds) when present. */
-    private void startCooldown(HttpResponse<byte[]> response) {
+    private void startBackoff(HttpResponse<byte[]> response) {
         long seconds = response.headers().firstValue("Retry-After")
                 .map(this::parseRetryAfterSeconds)
-                .orElse(DEFAULT_COOLDOWN_SECONDS);
-        cooldownUntil = Instant.now().plusSeconds(seconds);
+                .orElse(DEFAULT_BACKOFF_SECONDS);
+        backoffUntil = Instant.now().plusSeconds(seconds);
         log.warn("GTFS-RT feed at {} returned HTTP {} (quota/throttle); backing off {}s until {}",
-                gtfsRtUrl, response.statusCode(), seconds, cooldownUntil);
+                gtfsRtUrl, response.statusCode(), seconds, backoffUntil);
     }
 
     private long parseRetryAfterSeconds(String value) {
@@ -108,7 +113,7 @@ public class GtfsRtReader {
             return Math.max(0, Long.parseLong(value.trim()));
         } catch (NumberFormatException e) {
             // Retry-After may also be an HTTP-date; fall back rather than parse it precisely.
-            return DEFAULT_COOLDOWN_SECONDS;
+            return DEFAULT_BACKOFF_SECONDS;
         }
     }
 }

--- a/src/main/java/be/irail/api/gtfs/reader/GtfsRtUpdater.java
+++ b/src/main/java/be/irail/api/gtfs/reader/GtfsRtUpdater.java
@@ -40,9 +40,9 @@ public class GtfsRtUpdater {
 
     /**
      * Periodically fetches and processes GTFS-Realtime TripUpdates.
-     * Runs every 15 seconds.
+     * Interval is configurable via gtfs.rt.pollMs (default 30s, matching the upstream refresh cadence).
      */
-    @Scheduled(fixedRate = 15000)
+    @Scheduled(fixedRateString = "${gtfs.rt.pollMs:30000}")
     public void update() {
         GtfsInMemoryDao staticDao = GtfsInMemoryDao.getInstance();
         if (staticDao == null) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,13 @@
 spring.application.name=irail-java
 spring.threads.virtual.enabled=true
 
-gtfs.rt.url=https://sncb-opendata.hafas.de/gtfs/realtime/d22ad6759ee25bg84ddb6c818g4dc4de_TC
-# For Belgian Mobility, request binary protobuf, e.g. .../api/gtfs/feed/nmbssncb/rt/trip-update?format=protobuf
+# NMBS/SNCB GTFS-RT via FlatTurtle's mirror of the Belgian Mobility feed (binary protobuf, CC BY 4.0).
+# The mirror caches upstream (~30s) and keeps the Belgian Mobility partner key server-side.
+gtfs.rt.url=https://gtfs.flatturtle.cloud/sncb-nmbs/_realtime/trip-update
 gtfs.rt.pollMs=30000
-# API key for authenticated GTFS-RT feeds. Empty = unauthenticated (e.g. the hafas feed above).
-# Belgian Mobility authenticates with the bmc-partner-key header; Azure APIM's generic default is Ocp-Apim-Subscription-Key.
+# Access token for the mirror. Left empty here; set via the GTFS_RT_APIKEY environment variable in production.
 gtfs.rt.apiKey=
-gtfs.rt.apiKeyHeader=bmc-partner-key
+gtfs.rt.apiKeyHeader=x-rt-token
 gtfs.static.url=https://gtfs.flatturtle.cloud/sncb-nmbs/_latest/sncb-nmbs-gtfs.zip
 gtfs.static.range.back=2
 gtfs.static.range.forward=62

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,12 @@ spring.application.name=irail-java
 spring.threads.virtual.enabled=true
 
 gtfs.rt.url=https://sncb-opendata.hafas.de/gtfs/realtime/d22ad6759ee25bg84ddb6c818g4dc4de_TC
+# For Belgian Mobility, request binary protobuf, e.g. .../api/gtfs/feed/nmbssncb/rt/trip-update?format=protobuf
+gtfs.rt.pollMs=30000
+# API key for authenticated GTFS-RT feeds. Empty = unauthenticated (e.g. the hafas feed above).
+# Belgian Mobility authenticates with the bmc-partner-key header; Azure APIM's generic default is Ocp-Apim-Subscription-Key.
+gtfs.rt.apiKey=
+gtfs.rt.apiKeyHeader=bmc-partner-key
 gtfs.static.url=https://gtfs.flatturtle.cloud/sncb-nmbs/_latest/sncb-nmbs-gtfs.zip
 gtfs.static.range.back=2
 gtfs.static.range.forward=62

--- a/src/test/java/be/irail/api/gtfs/reader/GtfsRtReaderTest.java
+++ b/src/test/java/be/irail/api/gtfs/reader/GtfsRtReaderTest.java
@@ -1,0 +1,138 @@
+package be.irail.api.gtfs.reader;
+
+import com.google.transit.realtime.GtfsRealtime.FeedHeader;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Exercises the fetch behaviour this reader needs for an authenticated, quota-limited feed:
+ * sending the key, and backing off when the gateway refuses. Served by a local HTTP server so no
+ * request leaves the machine.
+ */
+class GtfsRtReaderTest {
+
+    private HttpServer server;
+    private final List<String> receivedKeys = new CopyOnWriteArrayList<>();
+    private int responseStatus = 200;
+    private String retryAfter;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        receivedKeys.clear();
+        responseStatus = 200;
+        retryAfter = null;
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/feed", this::handle);
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        receivedKeys.add(String.valueOf(exchange.getRequestHeaders().getFirst("bmc-partner-key")));
+        if (retryAfter != null) {
+            exchange.getResponseHeaders().add("Retry-After", retryAfter);
+        }
+        byte[] body = responseStatus == 200 ? feed() : "nope".getBytes();
+        exchange.sendResponseHeaders(responseStatus, body.length);
+        exchange.getResponseBody().write(body);
+        exchange.close();
+    }
+
+    private static byte[] feed() {
+        return FeedMessage.newBuilder()
+                .setHeader(FeedHeader.newBuilder().setGtfsRealtimeVersion("2.0").setTimestamp(1_787_000_000L))
+                .build()
+                .toByteArray();
+    }
+
+    private GtfsRtReader reader(String apiKey) {
+        GtfsRtReader reader = new GtfsRtReader();
+        ReflectionTestUtils.setField(reader, "gtfsRtUrl",
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/feed");
+        ReflectionTestUtils.setField(reader, "apiKey", apiKey);
+        ReflectionTestUtils.setField(reader, "apiKeyHeader", "bmc-partner-key");
+        return reader;
+    }
+
+    @Test
+    void sendsTheConfiguredKeyAndParsesTheFeed() {
+        FeedMessage feed = reader("a-partner-key").readTripUpdates();
+
+        assertNotNull(feed, "a 200 with valid protobuf should parse");
+        assertEquals("2.0", feed.getHeader().getGtfsRealtimeVersion());
+        assertEquals(List.of("a-partner-key"), receivedKeys);
+    }
+
+    @Test
+    void omitsTheHeaderWhenNoKeyIsConfigured() {
+        assertNotNull(reader("").readTripUpdates());
+
+        assertEquals(List.of("null"), receivedKeys, "no key configured means no key header");
+    }
+
+    @Test
+    void backsOffAfterAQuotaRefusalInsteadOfRetryingImmediately() {
+        responseStatus = 403;
+        retryAfter = "120";
+        GtfsRtReader reader = reader("a-partner-key");
+
+        assertNull(reader.readTripUpdates(), "a refused fetch yields no feed");
+        assertNull(reader.readTripUpdates(), "still refused while in cooldown");
+
+        assertEquals(1, receivedKeys.size(), "the second poll must not reach the gateway");
+    }
+
+    @Test
+    void backsOffOnRateLimitingToo() {
+        responseStatus = 429;
+        GtfsRtReader reader = reader("a-partner-key");
+
+        assertNull(reader.readTripUpdates());
+        assertNull(reader.readTripUpdates());
+
+        assertEquals(1, receivedKeys.size());
+    }
+
+    @Test
+    void toleratesARetryAfterThatIsNotANumber() {
+        responseStatus = 429;
+        retryAfter = "Wed, 19 Aug 2026 12:00:00 GMT";
+        GtfsRtReader reader = reader("a-partner-key");
+
+        assertNull(reader.readTripUpdates());
+        assertNull(reader.readTripUpdates(), "an HTTP-date falls back to the default cooldown");
+
+        assertEquals(1, receivedKeys.size());
+    }
+
+    @Test
+    void keepsPollingAfterAnUnexpectedStatus() {
+        // A 500 is a transient upstream fault, not a quota decision, so it must not silence the
+        // poller the way a 403 does.
+        responseStatus = 500;
+        GtfsRtReader reader = reader("a-partner-key");
+
+        assertNull(reader.readTripUpdates());
+        assertNull(reader.readTripUpdates());
+
+        assertEquals(2, receivedKeys.size(), "an unexpected status should not start a cooldown");
+    }
+}


### PR DESCRIPTION
Adds support for the Belgian Mobility GTFS-RT endpoints, which require a key.

The existing fetch was written for the hafas feed, which needs none. Pointed at BMC without a key it gets anonymous access, which the gateway caps and then answers with `403 Quota Exceeded`.

- `GtfsRtReader` moves from `url.openStream()` to `HttpClient` so a key header can be sent. Header name and value are configurable (`gtfs.rt.apiKeyHeader`, `gtfs.rt.apiKey`); BMC uses `bmc-partner-key`.
- On 403/429 it honours `Retry-After` and backs off rather than re-polling. Other statuses do not start a cooldown.
- Poll interval is configurable via `gtfs.rt.pollMs`, defaulting to 30s to match the BMC refresh rate.
- With `gtfs.rt.apiKey` empty no header is sent, so the hafas feed behaves exactly as before.

The second commit points the default `gtfs.rt.url` at FlatTurtle's cached mirror of the BMC feed, which keeps the partner key server-side. Happy to drop that commit if you would rather the default stayed vendor-neutral and the mirror were set through deployment env vars only.

**Tests** — `GtfsRtReaderTest` covers the key header, the 403 and 429 cooldowns including a non-numeric `Retry-After`, and that an unexpected status does not silence the poller. Served from a local `HttpServer`, so nothing leaves the machine.
