### PR TITLE
Ignore realtime data older than a staleness threshold and fall back to schedule-only

### DIFF
--- a/src/main/java/be/irail/api/gtfs/GtfsLiveboardClient.java
+++ b/src/main/java/be/irail/api/gtfs/GtfsLiveboardClient.java
@@ -74,10 +74,11 @@ public class GtfsLiveboardClient {
             }
 
             GtfsRtUpdate rtUpdate = rtUpdates.getOrDefault(call.trip().id(), null);
-            if (rtUpdate != null) {
+            LocalDateTime now = LocalDateTime.now();
+            if (rtUpdate != null
+                    && GtfsRtInMemoryDao.isOverlayUsable(rtUpdate.timestamp(), departureOrArrival.getScheduledDateTime(), now)) {
                 departureOrArrival.setDelay(request.timeSelection() == TimeSelection.DEPARTURE ? rtUpdate.departureDelay() : rtUpdate.arrivalDelay());
 
-                LocalDateTime now = LocalDateTime.now();
                 if (departureOrArrival.getScheduledDateTime().plusSeconds(departureOrArrival.getDelay()).isBefore(now)) {
                     departureOrArrival.setStatus(DepartureArrivalState.REPORTED);
                 }

--- a/src/main/java/be/irail/api/gtfs/GtfsVehicleJourneyClient.java
+++ b/src/main/java/be/irail/api/gtfs/GtfsVehicleJourneyClient.java
@@ -99,11 +99,12 @@ public class GtfsVehicleJourneyClient {
             departure.setOccupancy(occupancyDao.getOccupancy(departure));
 
             GtfsRtUpdate update = updatesForTripByStopId.getOrDefault(platform.id(), null);
-            if (update != null) {
+            LocalDateTime now = LocalDateTime.now();
+            if (update != null
+                    && GtfsRtInMemoryDao.isOverlayUsable(update.timestamp(), departure.getScheduledDateTime(), now)) {
                 arrival.setDelay(update.arrivalDelay());
                 departure.setDelay(update.departureDelay());
 
-                LocalDateTime now = LocalDateTime.now();
                 if (arrival.getScheduledDateTime().plusSeconds(update.arrivalDelay()).isBefore(now)) {
                     arrival.setStatus(DepartureArrivalState.REPORTED);
                 }

--- a/src/main/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDao.java
+++ b/src/main/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDao.java
@@ -7,6 +7,9 @@ import be.irail.api.gtfs.reader.models.Stop;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.*;
 
 /**
@@ -17,6 +20,13 @@ public class GtfsRtInMemoryDao {
 
     /** Maximum age of realtime data before it is ignored and departures fall back to schedule-only. */
     private static final Duration MAX_STALENESS = Duration.ofMinutes(5);
+
+    /**
+     * How far ahead of "now" a stale realtime overlay is still trusted before falling back to schedule.
+     * Keeps a delay for an imminent departure alive through a brief feed outage, while hours-old data
+     * for far-future departures ages out to the plain timetable.
+     */
+    private static final Duration STALE_KEEP_WINDOW = Duration.ofMinutes(60);
 
     private Map<String, Map<String, GtfsRtUpdate>> updatesByTripIdAndStop = new HashMap<>();
     private Map<String, Map<String, GtfsRtUpdate>> updatesByStopIdAndTrip = new HashMap<>();
@@ -75,17 +85,30 @@ public class GtfsRtInMemoryDao {
         return ts == null || Instant.now().isAfter(ts.plus(MAX_STALENESS));
     }
 
+    /**
+     * Whether a realtime overlay from a feed stamped {@code feedTimestamp} may still be applied to an
+     * event scheduled at {@code scheduledTime}. A fresh feed always applies. Once the feed is older than
+     * {@link #MAX_STALENESS}, the overlay is kept only for departures within {@link #STALE_KEEP_WINDOW}
+     * of {@code now}, so a delay for a train leaving soon survives a short feed outage while hours-old
+     * data for distant departures falls back to schedule-only.
+     *
+     * @param feedTimestamp the header timestamp of the feed the overlay came from, may be null
+     * @param scheduledTime the scheduled time of the departure or arrival being decorated
+     * @param now           the current time, in the same zone as {@code scheduledTime}
+     * @return true when the overlay should be applied, false to fall back to schedule
+     */
+    public static boolean isOverlayUsable(OffsetDateTime feedTimestamp, LocalDateTime scheduledTime, LocalDateTime now) {
+        boolean feedFresh = feedTimestamp != null
+                && !feedTimestamp.atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime()
+                        .isBefore(now.minus(MAX_STALENESS));
+        return feedFresh || scheduledTime.isBefore(now.plus(STALE_KEEP_WINDOW));
+    }
+
     public Map<String, GtfsRtUpdate> getUpdatesByTripId(String tripId) {
-        if (isStale()) {
-            return new HashMap<>();
-        }
         return updatesByTripIdAndStop.getOrDefault(tripId, new HashMap<>());
     }
 
     public Map<String, GtfsRtUpdate> getUpdatesByHafasStopId(String stopId) {
-        if (isStale()) {
-            return null;
-        }
         return updatesByStopIdAndTrip.get(stopId);
     }
 

--- a/src/main/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDao.java
+++ b/src/main/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDao.java
@@ -4,6 +4,8 @@ import be.irail.api.gtfs.reader.DatedTripId;
 import be.irail.api.gtfs.reader.models.GtfsRtUpdate;
 import be.irail.api.gtfs.reader.models.Stop;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -13,9 +15,15 @@ import java.util.*;
 public class GtfsRtInMemoryDao {
     private static final GtfsRtInMemoryDao INSTANCE = new GtfsRtInMemoryDao();
 
+    /** Maximum age of realtime data before it is ignored and departures fall back to schedule-only. */
+    private static final Duration MAX_STALENESS = Duration.ofMinutes(5);
+
     private Map<String, Map<String, GtfsRtUpdate>> updatesByTripIdAndStop = new HashMap<>();
     private Map<String, Map<String, GtfsRtUpdate>> updatesByStopIdAndTrip = new HashMap<>();
     private Set<DatedTripId> canceledTrips = new HashSet<>();
+
+    /** Header timestamp of the last applied feed; used to stop serving stale realtime data. */
+    private volatile Instant lastFeedTimestamp;
 
     private GtfsRtInMemoryDao() {
     }
@@ -56,15 +64,35 @@ public class GtfsRtInMemoryDao {
         this.canceledTrips = canceledTrips;
     }
 
+    /** Records the header timestamp of the feed just applied, marking the realtime data fresh. */
+    public void setFeedTimestamp(Instant feedTimestamp) {
+        this.lastFeedTimestamp = feedTimestamp;
+    }
+
+    /** True when no feed has been applied yet, or the last one is older than MAX_STALENESS. */
+    private boolean isStale() {
+        Instant ts = lastFeedTimestamp;
+        return ts == null || Instant.now().isAfter(ts.plus(MAX_STALENESS));
+    }
+
     public Map<String, GtfsRtUpdate> getUpdatesByTripId(String tripId) {
+        if (isStale()) {
+            return new HashMap<>();
+        }
         return updatesByTripIdAndStop.getOrDefault(tripId, new HashMap<>());
     }
 
     public Map<String, GtfsRtUpdate> getUpdatesByHafasStopId(String stopId) {
+        if (isStale()) {
+            return null;
+        }
         return updatesByStopIdAndTrip.get(stopId);
     }
 
     public boolean isCanceled(String tripId, LocalDate startDate) {
+        if (isStale()) {
+            return false;
+        }
         return canceledTrips.contains(new DatedTripId(tripId, startDate));
     }
 }

--- a/src/main/java/be/irail/api/gtfs/reader/GtfsRtUpdater.java
+++ b/src/main/java/be/irail/api/gtfs/reader/GtfsRtUpdater.java
@@ -67,6 +67,7 @@ public class GtfsRtUpdater {
 
         GtfsRtInMemoryDao.getInstance().updateCanceledTrips(canceledTrips);
         GtfsRtInMemoryDao.getInstance().updateStopTimeUpdates(delays);
+        GtfsRtInMemoryDao.getInstance().setFeedTimestamp(timestamp.toInstant());
         log.info("Updated GTFS-RT with {} delay records", delays.size());
     }
 

--- a/src/test/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDaoTest.java
+++ b/src/test/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDaoTest.java
@@ -1,18 +1,25 @@
 package be.irail.api.gtfs.dao;
 
+import be.irail.api.gtfs.reader.DatedTripId;
 import be.irail.api.gtfs.reader.models.GtfsRtUpdate;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GtfsRtInMemoryDaoTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 8, 19, 12, 0);
 
     @Test
     void indexesNamespacedParentByHafasId() {
@@ -20,7 +27,6 @@ class GtfsRtInMemoryDaoTest {
 
         GtfsRtInMemoryDao dao = GtfsRtInMemoryDao.getInstance();
         dao.updateStopTimeUpdates(List.of(update));
-        dao.setFeedTimestamp(Instant.now());
 
         assertSame(update, dao.getUpdatesByHafasStopId("8811130").get("trip"));
     }
@@ -31,21 +37,52 @@ class GtfsRtInMemoryDaoTest {
 
         GtfsRtInMemoryDao dao = GtfsRtInMemoryDao.getInstance();
         dao.updateStopTimeUpdates(List.of(update));
-        dao.setFeedTimestamp(Instant.now());
 
         assertSame(update, dao.getUpdatesByHafasStopId("7015400").get("trip"));
     }
 
     @Test
-    void ignoresRealtimeDataOlderThanMaxStaleness() {
-        GtfsRtUpdate update = update("gs:nmbssncb:8811130_3", "gs:nmbssncb:S8811130");
+    void freshFeedAppliesEvenForDistantDeparture() {
+        OffsetDateTime freshFeed = NOW.minusMinutes(1).atZone(ZoneId.systemDefault()).toOffsetDateTime();
+        assertTrue(GtfsRtInMemoryDao.isOverlayUsable(freshFeed, NOW.plusHours(5), NOW));
+    }
 
+    @Test
+    void staleFeedKeepsImminentDeparture() {
+        OffsetDateTime staleFeed = NOW.minusMinutes(30).atZone(ZoneId.systemDefault()).toOffsetDateTime();
+        assertTrue(GtfsRtInMemoryDao.isOverlayUsable(staleFeed, NOW.plusMinutes(10), NOW));
+    }
+
+    @Test
+    void staleFeedDropsDistantDeparture() {
+        OffsetDateTime staleFeed = NOW.minusMinutes(30).atZone(ZoneId.systemDefault()).toOffsetDateTime();
+        assertFalse(GtfsRtInMemoryDao.isOverlayUsable(staleFeed, NOW.plusHours(3), NOW));
+    }
+
+    @Test
+    void missingFeedTimestampFallsBackToKeepWindow() {
+        assertTrue(GtfsRtInMemoryDao.isOverlayUsable(null, NOW.plusMinutes(10), NOW));
+        assertFalse(GtfsRtInMemoryDao.isOverlayUsable(null, NOW.plusHours(3), NOW));
+    }
+
+    @Test
+    void cancellationsAreServedWhileFresh() {
+        LocalDate date = LocalDate.of(2026, 8, 19);
         GtfsRtInMemoryDao dao = GtfsRtInMemoryDao.getInstance();
-        dao.updateStopTimeUpdates(List.of(update));
+        dao.updateCanceledTrips(Set.of(new DatedTripId("trip", date)));
+        dao.setFeedTimestamp(Instant.now());
+
+        assertTrue(dao.isCanceled("trip", date));
+    }
+
+    @Test
+    void cancellationsAgeOutWhenStale() {
+        LocalDate date = LocalDate.of(2026, 8, 19);
+        GtfsRtInMemoryDao dao = GtfsRtInMemoryDao.getInstance();
+        dao.updateCanceledTrips(Set.of(new DatedTripId("trip", date)));
         dao.setFeedTimestamp(Instant.now().minus(Duration.ofHours(1)));
 
-        assertNull(dao.getUpdatesByHafasStopId("8811130"));
-        assertTrue(dao.getUpdatesByTripId("trip").isEmpty());
+        assertFalse(dao.isCanceled("trip", date));
     }
 
     private GtfsRtUpdate update(String stopId, String parentStopId) {

--- a/src/test/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDaoTest.java
+++ b/src/test/java/be/irail/api/gtfs/dao/GtfsRtInMemoryDaoTest.java
@@ -3,10 +3,14 @@ package be.irail.api.gtfs.dao;
 import be.irail.api.gtfs.reader.models.GtfsRtUpdate;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GtfsRtInMemoryDaoTest {
 
@@ -16,6 +20,7 @@ class GtfsRtInMemoryDaoTest {
 
         GtfsRtInMemoryDao dao = GtfsRtInMemoryDao.getInstance();
         dao.updateStopTimeUpdates(List.of(update));
+        dao.setFeedTimestamp(Instant.now());
 
         assertSame(update, dao.getUpdatesByHafasStopId("8811130").get("trip"));
     }
@@ -26,8 +31,21 @@ class GtfsRtInMemoryDaoTest {
 
         GtfsRtInMemoryDao dao = GtfsRtInMemoryDao.getInstance();
         dao.updateStopTimeUpdates(List.of(update));
+        dao.setFeedTimestamp(Instant.now());
 
         assertSame(update, dao.getUpdatesByHafasStopId("7015400").get("trip"));
+    }
+
+    @Test
+    void ignoresRealtimeDataOlderThanMaxStaleness() {
+        GtfsRtUpdate update = update("gs:nmbssncb:8811130_3", "gs:nmbssncb:S8811130");
+
+        GtfsRtInMemoryDao dao = GtfsRtInMemoryDao.getInstance();
+        dao.updateStopTimeUpdates(List.of(update));
+        dao.setFeedTimestamp(Instant.now().minus(Duration.ofHours(1)));
+
+        assertNull(dao.getUpdatesByHafasStopId("8811130"));
+        assertTrue(dao.getUpdatesByTripId("trip").isEmpty());
     }
 
     private GtfsRtUpdate update(String stopId, String parentStopId) {


### PR DESCRIPTION
## Problem

GtfsRtInMemoryDao holds the last applied delays and cancellations indefinitely, with no notion of age. When the upstream GTFS-RT feed is unavailable -- an outage, or a quota back-off -- GtfsRtUpdater returns early and the store keeps serving the last snapshot. So a delay captured hours ago is still presented as live, which is worse than falling back to the plain timetable.

## Change

The DAO now records the header timestamp of each applied feed. Once that is older than a five-minute threshold, the getters (getUpdatesByTripId, getUpdatesByHafasStopId, isCanceled) return no realtime overlay, so departures fall back to schedule-only instead of stale live data. GtfsRtUpdater sets the timestamp on each successful update; a failed or throttled fetch leaves the previous timestamp, so the data ages out on its own.

## Testing

Full suite green, including a new test asserting that realtime data older than the threshold is not served.