### PR TITLE
Report upstream errors instead of returning an empty connections result

### DIFF
--- a/src/main/java/be/irail/api/riv/NmbsRivJourneyPlanningClient.java
+++ b/src/main/java/be/irail/api/riv/NmbsRivJourneyPlanningClient.java
@@ -51,19 +51,44 @@ public class NmbsRivJourneyPlanningClient extends RivClient {
         if (json == null || json.isNull()) {
             throw new UpstreamServerException("The server did not return any data.");
         }
+        JsonNode trips = requireTripNode(json);
 
         JourneyPlanningSearchResult result = new JourneyPlanningSearchResult();
         result.setOriginStation(convertToModelStation(request.from(), request.language()));
         result.setDestinationStation(convertToModelStation(request.to(), request.language()));
 
         List<Journey> journeys = new ArrayList<>();
-        if (json.has("Trip") && json.get("Trip").isArray()) {
-            for (JsonNode tripNode : json.get("Trip")) {
+        if (trips.isArray()) {
+            for (JsonNode tripNode : trips) {
                 journeys.add(parseHafasTrip(request, tripNode));
             }
+        } else {
+            // A single result is not always wrapped in an array.
+            journeys.add(parseHafasTrip(request, trips));
         }
         result.setJourneys(journeys);
         return result;
+    }
+
+    /**
+     * Returns the Trip node of a journey planning response, or throws when it is absent.
+     * <p>
+     * A successful response always carries a Trip node, and "no journeys found" is reported upstream
+     * as errorCode SVC_NO_RESULT, which is raised before we get here. A response without Trip
+     * therefore means the upstream returned something we cannot interpret, such as the security
+     * layer's "7601 : _Threat.Requests : Enhanced Security request violation". Reporting that as an
+     * error beats returning an empty result set, which a client cannot tell apart from "there are
+     * genuinely no connections between these stations".
+     *
+     * @param json the parsed journey planning response
+     * @return the Trip node
+     */
+    static JsonNode requireTripNode(JsonNode json) {
+        JsonNode trips = json.get("Trip");
+        if (trips == null || trips.isNull()) {
+            throw new UpstreamServerException("The upstream server returned a response without journey planning data.");
+        }
+        return trips;
     }
 
     private Journey parseHafasTrip(JourneyPlanningRequest request, JsonNode tripNode) {

--- a/src/main/java/be/irail/api/riv/NmbsRivRawDataRepository.java
+++ b/src/main/java/be/irail/api/riv/NmbsRivRawDataRepository.java
@@ -356,7 +356,11 @@ public class NmbsRivRawDataRepository {
             if (response.statusCode() >= 500 && body.startsWith("ERROR reason : error : 9000")) {
                 throw new UpstreamServerUnavailableException();
             }
-            if (response.statusCode() >= 500) {
+            // Functional errors are reported by NMBS as HTTP 200 with an errorCode field, so any 4xx is an
+            // infrastructure or security-layer rejection, e.g. "7601 : _Threat.Requests : Enhanced Security
+            // request violation". Returning such a body would leave the caller with a response that parses
+            // fine but carries no journey data, which used to surface as an empty result set instead of an error.
+            if (response.statusCode() >= 400) {
                 throw new UpstreamServerException("Upstream server error: " + response.statusCode() + "\nBody: '" + body + "'");
             }
             return body;

--- a/src/test/java/be/irail/api/riv/NmbsRivJourneyPlanningClientTest.java
+++ b/src/test/java/be/irail/api/riv/NmbsRivJourneyPlanningClientTest.java
@@ -1,0 +1,62 @@
+package be.irail.api.riv;
+
+import be.irail.api.exception.upstream.UpstreamServerException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NmbsRivJourneyPlanningClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private JsonNode json(String raw) throws Exception {
+        return objectMapper.readTree(raw);
+    }
+
+    @Test
+    void returnsTheTripArrayOfARegularResponse() throws Exception {
+        JsonNode trips = NmbsRivJourneyPlanningClient.requireTripNode(json("{\"Trip\": [{\"idx\": \"0\"}, {\"idx\": \"1\"}]}"));
+
+        assertTrue(trips.isArray());
+        assertEquals(2, trips.size());
+    }
+
+    @Test
+    void returnsASingleTripThatIsNotWrappedInAnArray() throws Exception {
+        JsonNode trips = NmbsRivJourneyPlanningClient.requireTripNode(json("{\"Trip\": {\"idx\": \"0\"}}"));
+
+        assertTrue(trips.isObject());
+    }
+
+    @Test
+    void anEmptyTripArrayIsAValidResponse() throws Exception {
+        JsonNode trips = NmbsRivJourneyPlanningClient.requireTripNode(json("{\"Trip\": []}"));
+
+        assertTrue(trips.isArray());
+        assertEquals(0, trips.size());
+    }
+
+    @Test
+    void throwsWhenTheResponseCarriesNoTripNode() throws Exception {
+        // What the security layer returns for "7601 : _Threat.Requests : Enhanced Security request
+        // violation". Previously this parsed cleanly into zero connections, so callers received an
+        // empty result set with HTTP 200 instead of an error.
+        JsonNode securityViolation = json("{\"errorCode\": 7601, \"errorText\": \"_Threat.Requests : Enhanced Security request violation\"}");
+
+        assertThrows(UpstreamServerException.class, () -> NmbsRivJourneyPlanningClient.requireTripNode(securityViolation));
+    }
+
+    @Test
+    void throwsWhenTheResponseIsAnEmptyObject() throws Exception {
+        assertThrows(UpstreamServerException.class, () -> NmbsRivJourneyPlanningClient.requireTripNode(json("{}")));
+    }
+
+    @Test
+    void throwsWhenTheTripNodeIsExplicitlyNull() throws Exception {
+        assertThrows(UpstreamServerException.class, () -> NmbsRivJourneyPlanningClient.requireTripNode(json("{\"Trip\": null}")));
+    }
+}


### PR DESCRIPTION
Fixes #571.

## What
- Raise `UpstreamServerException` on any 4xx, not only 5xx.
- Require a `Trip` node before parsing journeys.
- Read a `Trip` returned as a bare object as one journey instead of skipping it.

## Why
`/connections` returned an empty result with HTTP 200 while NMBS was rejecting the request, e.g. `7601 : _Threat.Requests : Enhanced Security request violation`. A client cannot tell that apart from "no trains between these stations".

NMBS reports functional errors as HTTP 200 with an `errorCode`, so a 4xx is always an infrastructure or security rejection. The rejected body was cached for 60s, which is why it looked intermittent.

## Proof
`NmbsRivJourneyPlanningClientTest`, 6 cases: normal `Trip` array, single unwrapped `Trip`, legitimately empty array, the `7601` payload, an empty object, explicit `"Trip": null`.
