### PR TITLE
Add a results parameter to limit the number of connections returned

### DIFF
--- a/src/main/java/be/irail/api/controllers/v1/JourneyPlanningV1Controller.java
+++ b/src/main/java/be/irail/api/controllers/v1/JourneyPlanningV1Controller.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -71,6 +72,7 @@ public class JourneyPlanningV1Controller extends V1Controller {
      * @param typeOfTransport the type of transport filter
      * @param lang            the language for response data
      * @param format          the response format
+     * @param results         the maximum number of connections to return
      * @return the journey planning result
      */
     @GET
@@ -84,12 +86,14 @@ public class JourneyPlanningV1Controller extends V1Controller {
             @QueryParam("timesel") String timeselLowercase,
             @QueryParam("typeOfTransport") @DefaultValue("automatic") String typeOfTransport,
             @QueryParam("lang") @DefaultValue("en") String lang,
-            @QueryParam("format") @DefaultValue("xml") String format) {
+            @QueryParam("format") @DefaultValue("xml") String format,
+            @QueryParam("results") String results) {
         V1_JOURNEYPLANNING_REQUEST_METER.mark();
         TimeSelection timeSelection = parseTimesel(timesel, timeselLowercase);
         Language language = RequestParser.parseLanguage(lang);
         Format outputFormat = RequestParser.parseFormat(format);
         TypeOfTransportFilter transportFilter = parseTypeOfTransport(typeOfTransport);
+        Integer resultLimit = parseResults(results);
 
         Station fromDbStation = resolveStation(from, "from", "Missing required parameter 'from' for origin");
         Station toDbStation = resolveStation(to, "to", "Missing required parameter 'to' for destination");
@@ -111,7 +115,7 @@ public class JourneyPlanningV1Controller extends V1Controller {
         try {
             DataRoot dataRoot = cache.get(request, () -> loadJourneyPlanningResult(request));
             // Serialize to output format
-            Response response = v1Response(dataRoot, outputFormat);
+            Response response = v1Response(limitConnections(dataRoot, resultLimit), outputFormat);
             V1_JOURNEYPLANNING_SUCCESS_REQUEST_METER.mark();
             return response;
         } catch (UncheckedExecutionException | ExecutionException exception) {
@@ -126,6 +130,52 @@ public class JourneyPlanningV1Controller extends V1Controller {
             }
             throw new InternalProcessingException("Error fetching connections: " + exception.getCause().getMessage(), exception.getCause());
         }
+    }
+
+    /**
+     * Parses the optional 'results' parameter, which caps how many connections are returned.
+     *
+     * @param results the raw parameter value, may be null or empty
+     * @return the requested maximum, or null when the caller did not ask for a limit
+     */
+    static Integer parseResults(String results) {
+        if (results == null || results.isBlank()) {
+            return null;
+        }
+        int parsed;
+        try {
+            parsed = Integer.parseInt(results.trim());
+        } catch (NumberFormatException exception) {
+            throw new BadRequestException("Expected a positive whole number", "results", results);
+        }
+        if (parsed < 1) {
+            throw new BadRequestException("Expected a positive whole number", "results", results);
+        }
+        return parsed;
+    }
+
+    /**
+     * Limits the number of connections in the response.
+     * <p>
+     * Returns a copy rather than modifying the DataRoot in place: results are cached per journey
+     * planning request, and that cache is shared by callers asking for different numbers of results.
+     * Upstream is still queried for the full set, so a limited request reuses the same cache entry.
+     *
+     * @param dataRoot the full result
+     * @param limit    the maximum number of connections, or null for no limit
+     * @return a result with at most 'limit' connections
+     */
+    static DataRoot limitConnections(DataRoot dataRoot, Integer limit) {
+        if (limit == null
+                || !(dataRoot.connection instanceof Object[] connections)
+                || connections.length <= limit) {
+            return dataRoot;
+        }
+        DataRoot limited = new DataRoot(dataRoot.getRootName());
+        limited.version = dataRoot.version;
+        limited.timestamp = dataRoot.timestamp;
+        limited.connection = Arrays.copyOf(connections, limit);
+        return limited;
     }
 
     private static TimeSelection parseTimesel(String timesel, String timeselLowercase) {

--- a/src/test/java/be/irail/api/controllers/v1/JourneyPlanningV1ControllerTest.java
+++ b/src/test/java/be/irail/api/controllers/v1/JourneyPlanningV1ControllerTest.java
@@ -1,0 +1,94 @@
+package be.irail.api.controllers.v1;
+
+import be.irail.api.exception.request.BadRequestException;
+import be.irail.api.legacy.DataRoot;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JourneyPlanningV1ControllerTest {
+
+    private static DataRoot connectionsDataRoot(int count) {
+        DataRoot dataRoot = new DataRoot("connections");
+        Object[] connections = new Object[count];
+        for (int i = 0; i < count; i++) {
+            connections[i] = "connection-" + i;
+        }
+        dataRoot.connection = connections;
+        return dataRoot;
+    }
+
+    @Test
+    void parseResultsWithoutValueReturnsNoLimit() {
+        assertNull(JourneyPlanningV1Controller.parseResults(null));
+        assertNull(JourneyPlanningV1Controller.parseResults(""));
+        assertNull(JourneyPlanningV1Controller.parseResults("  "));
+    }
+
+    @Test
+    void parseResultsAcceptsPositiveNumbers() {
+        assertEquals(1, JourneyPlanningV1Controller.parseResults("1"));
+        assertEquals(3, JourneyPlanningV1Controller.parseResults(" 3 "));
+    }
+
+    @Test
+    void parseResultsRejectsZeroAndNegativeNumbers() {
+        assertThrows(BadRequestException.class, () -> JourneyPlanningV1Controller.parseResults("0"));
+        assertThrows(BadRequestException.class, () -> JourneyPlanningV1Controller.parseResults("-2"));
+    }
+
+    @Test
+    void parseResultsRejectsNonNumericValues() {
+        assertThrows(BadRequestException.class, () -> JourneyPlanningV1Controller.parseResults("all"));
+        assertThrows(BadRequestException.class, () -> JourneyPlanningV1Controller.parseResults("1.5"));
+    }
+
+    @Test
+    void limitConnectionsTruncatesToRequestedSize() {
+        DataRoot full = connectionsDataRoot(6);
+
+        DataRoot limited = JourneyPlanningV1Controller.limitConnections(full, 2);
+
+        assertArrayEquals(new Object[]{"connection-0", "connection-1"}, (Object[]) limited.connection);
+        assertEquals(full.version, limited.version);
+        assertEquals(full.timestamp, limited.timestamp);
+        assertEquals(full.getRootName(), limited.getRootName());
+    }
+
+    @Test
+    void limitConnectionsLeavesTheCachedResultUntouched() {
+        DataRoot full = connectionsDataRoot(6);
+
+        JourneyPlanningV1Controller.limitConnections(full, 2);
+
+        assertEquals(6, ((Object[]) full.connection).length);
+    }
+
+    @Test
+    void limitConnectionsWithoutLimitReturnsTheSameInstance() {
+        DataRoot full = connectionsDataRoot(6);
+
+        assertSame(full, JourneyPlanningV1Controller.limitConnections(full, null));
+    }
+
+    @Test
+    void limitConnectionsLargerThanTheResultSetReturnsEverything() {
+        DataRoot full = connectionsDataRoot(3);
+
+        DataRoot limited = JourneyPlanningV1Controller.limitConnections(full, 10);
+
+        assertSame(full, limited);
+        assertEquals(3, ((Object[]) limited.connection).length);
+    }
+
+    @Test
+    void limitConnectionsHandlesAResultWithoutConnections() {
+        DataRoot empty = new DataRoot("connections");
+
+        assertSame(empty, JourneyPlanningV1Controller.limitConnections(empty, 1));
+    }
+}


### PR DESCRIPTION
Fixes #552.

## What
Re-introduces the `results` parameter from the PHP implementation, capping how many connections are serialised. Omitting it keeps current behaviour exactly.

## Why
`/connections` always serialises every journey — measured today on the reporter's request (`from=Gent-Sint-Pieters&to=Hasselt&format=json`): **45,289 bytes for 7 connections**. The reporter's departure board runs on an ESP32 with 320 kB of RAM total, shared with the Wi-Fi stack and an HTTPS client. `results=1` brings that query to roughly 7 kB.

Two deliberate choices:
- Applied **after** the cache, not by lowering upstream `numF`, so requests differing only in `results` share one cache entry and one upstream call.
- The cached `DataRoot` is copied, not truncated in place, since the same instance is served to every caller.

V1 `/connections` only, which is the endpoint in the issue. Happy to extend to V2 `/journeyplanning` in a follow-up.

## Proof
`JourneyPlanningV1ControllerTest`, 9 cases: parameter parsing (absent, blank, valid, zero, negative, non-numeric) and truncation (exact truncation, cached result left untouched, no-limit and over-limit returning the original instance, empty result).
