### PR TITLE
Match station search queries literally instead of compiling them as regexes

### DIFF
--- a/src/main/java/be/irail/api/db/StationsDao.java
+++ b/src/main/java/be/irail/api/db/StationsDao.java
@@ -57,11 +57,12 @@ public class StationsDao {
                 String normalizedQuery = standardizeQuery(query);
                 normalizedQuery = normalizeAccents(normalizedQuery);
                 normalizedQuery = normalize(normalizedQuery);
+                StationNameMatcher matcher = StationNameMatcher.forQuery(normalizedQuery);
                 int count = 0;
                 List<Station> resultStations = new ArrayList<>();
 
                 for (Station station : this.stationsSortedBySize) {
-                    StationMatchResult stationMatchResult = evaluateStationMatch(station, normalizedQuery);
+                    StationMatchResult stationMatchResult = evaluateStationMatch(station, matcher);
 
                     if (stationMatchResult.exactMatch()) {
                         putInFirstPlace(resultStations, station);
@@ -109,7 +110,7 @@ public class StationsDao {
         stationByNameCache.invalidateAll();
     }
 
-    private StationsDao.StationMatchResult evaluateStationMatch(Station station, String normalizedQuery) {
+    private StationsDao.StationMatchResult evaluateStationMatch(Station station, StationNameMatcher matcher) {
         boolean exactMatch = false;
         boolean partialMatch = false;
 
@@ -123,12 +124,12 @@ public class StationsDao {
             String testStationName = normalize(normalizeAccents(name));
             testStationName = testStationName.replaceAll("([- ])+", " ");
 
-            if (isEqualCaseInsensitive(normalizedQuery, testStationName)) {
+            if (matcher.isEqualCaseInsensitive(testStationName)) {
                 exactMatch = true;
                 break;
             }
 
-            if (isQueryPartOfName(normalizedQuery, testStationName)) {
+            if (matcher.isQueryPartOfName(testStationName)) {
                 partialMatch = true;
             }
         }
@@ -286,18 +287,6 @@ public class StationsDao {
         return str;
     }
 
-    private boolean isQueryPartOfName(String query, String testStationName) {
-        Pattern pattern = Pattern.compile(query, Pattern.CASE_INSENSITIVE);
-        return pattern.matcher(testStationName).find()
-                || pattern.matcher(testStationName.replace("'", " ")).find();
-    }
-
-    private boolean isEqualCaseInsensitive(String query, String testStationName) {
-        Pattern pattern = Pattern.compile("^" + query + "$", Pattern.CASE_INSENSITIVE);
-        return pattern.matcher(testStationName).matches()
-                || pattern.matcher(testStationName.replace("'", " ")).matches();
-    }
-
     private void putInFirstPlace(List<Station> list, Station value) {
         list.remove(value);
         list.addFirst(value);
@@ -335,6 +324,36 @@ public class StationsDao {
             stationsById.put(station.getIrailId(), station);
         }
         log.info("Loaded {} stations from database", allStations.size());
+    }
+
+    /**
+     * The compiled matchers for a single search query.
+     * <p>
+     * The query originates from a request parameter, so it is quoted before being compiled: a station name is never a
+     * regular expression, and treating it as one made {@code ?station=Brussel)} fail to compile while
+     * {@code ?station=.*} matched every station in the list.
+     * <p>
+     * Both patterns only depend on the query, so they are built once per search rather than once per station name.
+     */
+    private record StationNameMatcher(Pattern exactPattern, Pattern partialPattern) {
+
+        private static StationNameMatcher forQuery(String normalizedQuery) {
+            String literalQuery = Pattern.quote(normalizedQuery);
+            return new StationNameMatcher(
+                    Pattern.compile("^" + literalQuery + "$", Pattern.CASE_INSENSITIVE),
+                    Pattern.compile(literalQuery, Pattern.CASE_INSENSITIVE)
+            );
+        }
+
+        private boolean isEqualCaseInsensitive(String testStationName) {
+            return exactPattern.matcher(testStationName).matches()
+                    || exactPattern.matcher(testStationName.replace("'", " ")).matches();
+        }
+
+        private boolean isQueryPartOfName(String testStationName) {
+            return partialPattern.matcher(testStationName).find()
+                    || partialPattern.matcher(testStationName.replace("'", " ")).find();
+        }
     }
 
     private record StationMatchResult(boolean exactMatch, boolean partialMatch) {

--- a/src/test/java/be/irail/api/db/StationsDaoTest.java
+++ b/src/test/java/be/irail/api/db/StationsDaoTest.java
@@ -2,6 +2,8 @@ package be.irail.api.db;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -77,6 +79,32 @@ class StationsDaoTest {
         assertNotNull(stations);
         assertEquals(1, stations.size());
         assertEquals("Moûtiers-Salins-Brides-les-Bai", stations.getFirst().getName());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Brussel)", "Brugge(", "Gent[", "Brussel+", "Li*ge", "Namur?", "\\\\Brussel"})
+    void getStations_queryContainingRegexCharacters_shouldNotFail(String query) {
+        // A station name is not a pattern. Compiling the query as one turned ordinary punctuation into a
+        // PatternSyntaxException, which surfaces as HTTP 500 on e.g. /v1/liveboard?station=Brussel)
+        // and /v1/connections?from=Brussel).
+        List<Station> stations = assertDoesNotThrow(() -> dao.getStations(query));
+        assertTrue(stations.isEmpty(), "No station name contains '" + query + "'");
+    }
+
+    @Test
+    void getStations_regexWildcardQuery_shouldBeMatchedLiterally() {
+        // ".*" is a valid pattern matching every name, so this used to report the first stations in the list
+        // as exact matches instead of returning nothing.
+        List<Station> stations = dao.getStations(".*");
+        assertTrue(stations.isEmpty(), "'.*' is not part of any station name");
+    }
+
+    @Test
+    void getStations_nameContainingRegexCharacters_shouldStillMatchLiterally() {
+        // Quoting must not break names that legitimately contain characters which are also metacharacters.
+        List<Station> stations = dao.getStations("Brussel-Zuid/Bruxelles-Midi");
+        assertEquals(1, stations.size());
+        assertEquals("008814001", stations.getFirst().getIrailId());
     }
 
     @Test


### PR DESCRIPTION
`StationsDao` compiles the incoming search query straight into a `Pattern`, so a station name supplied by a client is evaluated as a regular expression.

### Ordinary punctuation returns HTTP 500

```
GET /v1/liveboard?station=Brussel)
GET /v1/connections?from=Brussel)
```

`Pattern.compile("Brussel)")` raises `PatternSyntaxException`; `getStations` wraps it in `InternalProcessingException` and `IrailExceptionMapper` turns it into a 500 with a stack trace. A client typo is reported as a server fault.

### Metacharacters match where they should not

`?station=.*` compiles to a pattern that matches every name, so it is reported as an *exact* match against the first stations in the list instead of returning nothing. Any query containing `.`, `*`, `+`, `?`, `[` or `\` silently changes which stations are returned — and `/v1/connections` resolves `from`/`to` by taking `getStations(...).getFirst()`, so this decides which station the journey is actually planned for.

### Fix

`Pattern.quote` the query before compiling. Station names are compared literally, which is what the search has always meant — no ordinary lookup changes behaviour.

While in there, the two patterns depend only on the query, so they are built once per search instead of once per name per station. That was roughly 15k `Pattern.compile` calls for a single uncached lookup over the full station list.

### Tests

Added to `StationsDaoTest`:
- a parameterised case over queries containing `) ( [ + * ? \` — each must return no results rather than throw
- `.*` must be matched literally
- a name that legitimately contains `-` and `/` must still resolve, so quoting doesn't regress normal lookups

Before the fix 3 of the new cases fail (2 × `PatternSyntaxException`, 1 wrong result); after, all pass.

Full suite on H2: **34 tests, 1 error** — the pre-existing `IrailJavaApplicationTests.contextLoads`, which needs Postgres and is unrelated to this change (#585).

### Note

I looked at whether this is also a ReDoS vector and **could not demonstrate one**: `normalize()` strips balanced parentheses before compilation, and station names are short enough that I could not construct a query that backtracks meaningfully. The two problems above are the ones I can reproduce, so I've kept the claim to those.
