### PR TITLE
Give Vehicle value equality so the composition cache can be hit

### DIFF
--- a/src/main/java/be/irail/api/dto/Vehicle.java
+++ b/src/main/java/be/irail/api/dto/Vehicle.java
@@ -122,4 +122,32 @@ public class Vehicle {
     public LocalDate getJourneyStartDate() {
         return this.journeyStartDate;
     }
+
+    /**
+     * Two vehicles describe the same dated journey when their type, number and start date match. The direction is
+     * excluded: it is metadata about the same journey, filled in later and from different sources depending on the
+     * endpoint, so including it would make otherwise identical journeys unequal.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Vehicle other)) {
+            return false;
+        }
+        return number == other.number
+                && Objects.equals(type, other.type)
+                && Objects.equals(journeyStartDate, other.journeyStartDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, number, journeyStartDate);
+    }
+
+    @Override
+    public String toString() {
+        return getName() + " on " + journeyStartDate;
+    }
 }

--- a/src/test/java/be/irail/api/dto/VehicleTest.java
+++ b/src/test/java/be/irail/api/dto/VehicleTest.java
@@ -1,0 +1,63 @@
+package be.irail.api.dto;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class VehicleTest {
+
+    private static final LocalDate JOURNEY_START = LocalDate.of(2026, 8, 17);
+
+    @Test
+    void vehiclesForTheSameDatedJourneyAreEqual() {
+        Vehicle first = Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START);
+        Vehicle second = Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START);
+
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    void aDifferentTypeNumberOrStartDateIsADifferentVehicle() {
+        Vehicle vehicle = Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START);
+
+        assertNotEquals(vehicle, Vehicle.fromTypeAndNumber("S10", 538, JOURNEY_START));
+        assertNotEquals(vehicle, Vehicle.fromTypeAndNumber("IC", 539, JOURNEY_START));
+        assertNotEquals(vehicle, Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START.plusDays(1)));
+    }
+
+    @Test
+    void theDirectionDoesNotAffectEquality() {
+        // The direction is filled in after construction, from a different source per endpoint. It describes the
+        // same journey, so it must not split cache entries.
+        Vehicle withoutDirection = Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START);
+        Vehicle withDirection = Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START);
+        withDirection.setDirection(new VehicleDirection("Oostende", null));
+
+        assertEquals(withoutDirection, withDirection);
+        assertEquals(withoutDirection.hashCode(), withDirection.hashCode());
+    }
+
+    @Test
+    void aVehicleKeyedCacheHitsForAFreshlyBuiltEquivalentVehicle() {
+        // NmbsRivCompositionClient caches its RIV responses under a Vehicle. Every request builds a new Vehicle
+        // instance from the GTFS data, so without value equality that cache could never be hit and each
+        // /v1/composition request reached the upstream API again.
+        Cache<Vehicle, String> cache = CacheBuilder.newBuilder()
+                .maximumSize(10)
+                .expireAfterWrite(30, TimeUnit.MINUTES)
+                .build();
+        cache.put(Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START), "composition");
+
+        String cached = cache.getIfPresent(Vehicle.fromTypeAndNumber("IC", 538, JOURNEY_START));
+
+        assertSame("composition", cached);
+    }
+}


### PR DESCRIPTION
## What
Implement `equals`/`hashCode` on `Vehicle` over type, number and journey start date. Also a `toString`, since `Vehicle` appears in log statements.

## Why
`NmbsRivCompositionClient` caches in a `Cache<Vehicle, VehicleCompositionSearchResult>`, but `Vehicle` inherited identity equality. Every request builds a fresh instance via `Vehicle.fromTypeAndNumber`, so the key was never the same object twice and the cache could never hit — each miss called `commercialtraincompositionsbetweenptcars` again for a composition already in memory.

The controller's own 15-minute cache hides this for repeat requests with identical parameters, but not across languages (`CompositionRequest` includes `Language`, so nl/fr/en/de is four upstream calls for one train), nor between controller-cache expiry and the composition cache's 30-minute TTL.

`direction` is excluded from equality: it is set after construction, from different sources per endpoint, and describes the same journey. `Vehicle` is used as a collection key in exactly one place, so nothing else is affected.

## Proof
`VehicleTest`, 4 cases: same dated journey equal and hashing equally, differing type/number/start date unequal, direction not affecting equality, and a Guava cache configured like the composition one hitting for a freshly built equivalent `Vehicle`. Three fail before the change; the cache case fails with `expected: <composition> but was: <null>`, which is the bug.
