### PR TITLE
Match realtime trips to the schedule instead of comparing trip ids

### DIFF
--- a/src/main/java/be/irail/api/gtfs/dao/GtfsInMemoryDao.java
+++ b/src/main/java/be/irail/api/gtfs/dao/GtfsInMemoryDao.java
@@ -29,6 +29,7 @@ public class GtfsInMemoryDao {
     private static final int SECONDS_IN_DAY = 86400;
     private static final int SERVICE_DAY_END_HOUR = 4;
     private static final int GTFS_LOCATION_TYPE_STATION = 1;
+    private static final String TRIP_ID_NAMESPACE_PREFIX = "gt:";
 
     private static volatile GtfsInMemoryDao instance = null;
 
@@ -42,6 +43,7 @@ public class GtfsInMemoryDao {
     private final ArrayListMultimap<String, StopTime> stopTimesByStopId;
     private final ArrayListMultimap<Integer, Trip> tripsByShortName;
     private final HashMap<String, Trip> tripsById;
+    private final HashMultimap<String, String> tripIdsByIdBody;
     private final Cache<JourneyNumberAndDate, Optional<JourneyWithOriginAndDestination>> cache = CacheBuilder.newBuilder()
             .maximumSize(2000)
             .expireAfterWrite(4, TimeUnit.HOURS)
@@ -66,10 +68,12 @@ public class GtfsInMemoryDao {
         this.tripsByShortName = ArrayListMultimap.create();
         this.tripIdsByDate = HashMultimap.create();
         this.tripsById = new HashMap<>();
+        this.tripIdsByIdBody = HashMultimap.create();
         data.trips().forEach(t -> {
             tripsByShortName.put(t.shortName(), t);
             calendarDatesByServiceId.get(t.serviceId()).forEach(date -> tripIdsByDate.put(date, new TripIdAndStartDate(t.id(), date)));
             tripsById.put(t.id(), t);
+            tripIdsByIdBody.put(tripIdMatchKey(t.id()), t.id());
         });
 
         this.stopTimesByTripId = ArrayListMultimap.create();
@@ -152,6 +156,71 @@ public class GtfsInMemoryDao {
 
     public Trip getTrip(String tripId) {
         return tripsById.get(tripId);
+    }
+
+    /**
+     * Strips the trailing date component from a GTFS trip id.
+     *
+     * <p>NMBS trip ids end in a date, e.g.
+     * {@code gt:nmbssncb:88____:UUU::8775100:8814001:8:1834:20260810}. That date is not the service
+     * date: the static feed uses it to tell apart service patterns of the same run, while
+     * GTFS-Realtime puts the actual service date there. The part before it is stable across both
+     * feeds, so it is what the two can be matched on.
+     *
+     * @param tripId a GTFS trip id
+     * @return the trip id without its trailing {@code :date} component, or the id unchanged if it has none
+     */
+    public static String tripIdBody(String tripId) {
+        int lastSeparator = tripId.lastIndexOf(':');
+        return lastSeparator < 0 ? tripId : tripId.substring(0, lastSeparator);
+    }
+
+    /**
+     * Builds the key on which realtime and scheduled trip ids can be compared.
+     *
+     * <p>On top of the trailing date (see {@link #tripIdBody(String)}) the two feeds disagree on the
+     * leading namespace: the Belgian Mobility feeds prefix ids with {@code gt:<agency>:} while the
+     * hafas feed at {@code sncb-opendata.hafas.de} omits it entirely. Dropping that prefix is what
+     * lets a realtime trip from either source be looked up in the same index.
+     *
+     * @param tripId a trip id from either feed
+     * @return the id without a leading {@code gt:<agency>:} namespace and without its trailing date
+     */
+    public static String tripIdMatchKey(String tripId) {
+        String withoutDate = tripIdBody(tripId);
+        if (!withoutDate.startsWith(TRIP_ID_NAMESPACE_PREFIX)) {
+            return withoutDate;
+        }
+        int agencySeparator = withoutDate.indexOf(':', TRIP_ID_NAMESPACE_PREFIX.length());
+        return agencySeparator < 0 ? withoutDate : withoutDate.substring(agencySeparator + 1);
+    }
+
+    /**
+     * Resolves a GTFS-Realtime trip id to the static trip id of the run operating on a given date.
+     *
+     * <p>Comparing realtime and static trip ids directly almost never matches, because the two feeds
+     * put different dates in the trailing component (see {@link #tripIdBody(String)}). Instead the
+     * candidates sharing a trip id body are narrowed down to the one whose service actually runs on
+     * {@code serviceDate}. In the current NMBS feed that leaves at most one candidate for all but a
+     * handful of the 14 408 bodies that have several; those remaining ties are broken on the lowest
+     * trip id so the result stays stable between feed refreshes.
+     *
+     * @param tripId      a trip id from either feed
+     * @param serviceDate the date the trip is running on
+     * @return the matching static trip id, or empty when no known trip runs that day
+     */
+    public Optional<String> resolveTripIdForServiceDate(String tripId, LocalDate serviceDate) {
+        if (tripsById.containsKey(tripId)) {
+            return Optional.of(tripId);
+        }
+        return tripIdsByIdBody.get(tripIdMatchKey(tripId)).stream()
+                .filter(candidate -> runsOn(candidate, serviceDate))
+                .min(Comparator.naturalOrder());
+    }
+
+    private boolean runsOn(String tripId, LocalDate serviceDate) {
+        Trip trip = tripsById.get(tripId);
+        return trip != null && calendarDatesByServiceId.get(trip.serviceId()).contains(serviceDate);
     }
 
     public Stop getStop(StopTime stopTime, LocalDate startDate) {

--- a/src/main/java/be/irail/api/gtfs/reader/GtfsRtUpdater.java
+++ b/src/main/java/be/irail/api/gtfs/reader/GtfsRtUpdater.java
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -59,22 +60,42 @@ public class GtfsRtUpdater {
         OffsetDateTime timestamp = OffsetDateTime.ofInstant(Instant.ofEpochSecond(feed.getHeader().getTimestamp()), ZoneOffset.UTC);
         Set<DatedTripId> canceledTrips = new HashSet<>();
 
+        int matched = 0;
+        int unmatched = 0;
         for (FeedEntity entity : feed.getEntityList()) {
             if (entity.hasTripUpdate()) {
-                handleOneTripUpdate(entity, staticDao, delays, timestamp, canceledTrips);
+                if (handleOneTripUpdate(entity, staticDao, delays, timestamp, canceledTrips)) {
+                    matched++;
+                } else {
+                    unmatched++;
+                }
             }
         }
 
         GtfsRtInMemoryDao.getInstance().updateCanceledTrips(canceledTrips);
         GtfsRtInMemoryDao.getInstance().updateStopTimeUpdates(delays);
-        log.info("Updated GTFS-RT with {} delay records", delays.size());
+        log.info("Updated GTFS-RT with {} delay records from {} trips, {} realtime trips had no counterpart in the schedule",
+                delays.size(), matched, unmatched);
     }
 
-    private static void handleOneTripUpdate(FeedEntity entity, GtfsInMemoryDao staticDao, List<GtfsRtUpdate> delays,
-                                            OffsetDateTime timestamp, Set<DatedTripId> canceledTrips) {
+    /**
+     * Applies a single realtime TripUpdate to the collections being built for this refresh.
+     *
+     * @return whether the realtime trip could be matched to a trip in the GTFS schedule
+     */
+    private static boolean handleOneTripUpdate(FeedEntity entity, GtfsInMemoryDao staticDao, List<GtfsRtUpdate> delays,
+                                               OffsetDateTime timestamp, Set<DatedTripId> canceledTrips) {
         TripUpdate tu = entity.getTripUpdate();
-        String tripId = tu.getTrip().getTripId();
         LocalDate startDate = LocalDate.parse(tu.getTrip().getStartDate(), DATEFORMAT_YYYYMMDD);
+
+        // Realtime and static trip ids carry a different trailing date, so they have to be matched
+        // through the schedule rather than compared as strings.
+        Optional<String> scheduledTripId = staticDao.resolveTripIdForServiceDate(tu.getTrip().getTripId(), startDate);
+        if (scheduledTripId.isEmpty()) {
+            log.debug("No scheduled trip matches realtime trip {} on {}", tu.getTrip().getTripId(), startDate);
+            return false;
+        }
+        String tripId = scheduledTripId.get();
 
         for (TripUpdate.StopTimeUpdate stu : tu.getStopTimeUpdateList()) {
             String stopId = stu.getStopId();
@@ -94,6 +115,7 @@ public class GtfsRtUpdater {
         if (tu.getTrip().getScheduleRelationship() == GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED) {
             canceledTrips.add(new DatedTripId(tripId, startDate));
         }
+        return true;
     }
 
 }

--- a/src/test/java/be/irail/api/gtfs/dao/GtfsInMemoryDaoTest.java
+++ b/src/test/java/be/irail/api/gtfs/dao/GtfsInMemoryDaoTest.java
@@ -7,10 +7,14 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class GtfsInMemoryDaoTest {
+
+    private static final LocalDate MONDAY = LocalDate.of(2026, 8, 17);
+    private static final LocalDate TUESDAY = LocalDate.of(2026, 8, 18);
 
     @Test
     void supportsNamespacedServiceIds() {
@@ -30,5 +34,100 @@ class GtfsInMemoryDaoTest {
 
         assertEquals(List.of(serviceDate), List.copyOf(dao.getCalendarDates(serviceId)));
         assertEquals("trip-id", dao.getTrip("trip-id").id());
+    }
+
+    @Test
+    void tripIdBody_stripsOnlyTheTrailingDate() {
+        assertEquals("gt:nmbssncb:88____:UUU::8775100:8814001:8:1834",
+                GtfsInMemoryDao.tripIdBody("gt:nmbssncb:88____:UUU::8775100:8814001:8:1834:20260810"));
+        assertEquals("no-separators", GtfsInMemoryDao.tripIdBody("no-separators"));
+    }
+
+    @Test
+    void tripIdMatchKey_dropsTheFeedNamespaceAndTheTrailingDate() {
+        // The Belgian Mobility feeds namespace their ids, the hafas feed does not. Both must reduce
+        // to the same key or a realtime trip can never be found in the schedule.
+        assertEquals("88____:UUU::8775100:8814001:8:1834",
+                GtfsInMemoryDao.tripIdMatchKey("gt:nmbssncb:88____:UUU::8775100:8814001:8:1834:20260810"));
+        assertEquals("88____:UUU::8775100:8814001:8:1834",
+                GtfsInMemoryDao.tripIdMatchKey("88____:UUU::8775100:8814001:8:1834:20260819"));
+    }
+
+    @Test
+    void resolveTripIdForServiceDate_matchesAnIdWithoutTheFeedNamespace() {
+        GtfsInMemoryDao dao = daoWith(
+                trip("gt:nmbssncb:88____:007::8814001:8892007:3:1105:20260810", "service-monday"),
+                List.of(new CalendarDate("service-monday", MONDAY)));
+
+        assertEquals(Optional.of("gt:nmbssncb:88____:007::8814001:8892007:3:1105:20260810"),
+                dao.resolveTripIdForServiceDate("88____:007::8814001:8892007:3:1105:20260817", MONDAY));
+    }
+
+    @Test
+    void resolveTripIdForServiceDate_matchesAcrossDifferingTrailingDates() {
+        // The static feed stamps a trip id with a date identifying the service pattern, while
+        // GTFS-Realtime puts the actual service date there. Comparing the two as strings never matches.
+        GtfsInMemoryDao dao = daoWith(
+                trip("gt:nmbssncb:88____:007::8814001:8892007:3:1105:20260810", "service-monday"),
+                List.of(new CalendarDate("service-monday", MONDAY)));
+
+        assertEquals(Optional.of("gt:nmbssncb:88____:007::8814001:8892007:3:1105:20260810"),
+                dao.resolveTripIdForServiceDate("gt:nmbssncb:88____:007::8814001:8892007:3:1105:20260817", MONDAY));
+    }
+
+    @Test
+    void resolveTripIdForServiceDate_picksTheCandidateRunningThatDay() {
+        // One route body, two service patterns — only the calendar tells them apart.
+        String body = "gt:nmbssncb:BBUS__:049::8885001:8886009:3:558";
+        GtfsReader.GtfsData data = new GtfsReader.GtfsData(null, List.of(),
+                List.of(new CalendarDate("service-monday", MONDAY), new CalendarDate("service-tuesday", TUESDAY)),
+                List.of(), List.of(), List.of(),
+                List.of(new Trip(body + ":20260621", "route-id", "service-monday", "Brugge", 1905, 0, null),
+                        new Trip(body + ":20260628", "route-id", "service-tuesday", "Brugge", 1905, 0, null)));
+        GtfsInMemoryDao dao = new GtfsInMemoryDao(data);
+
+        assertEquals(Optional.of(body + ":20260621"), dao.resolveTripIdForServiceDate(body + ":20260817", MONDAY));
+        assertEquals(Optional.of(body + ":20260628"), dao.resolveTripIdForServiceDate(body + ":20260818", TUESDAY));
+    }
+
+    @Test
+    void resolveTripIdForServiceDate_isEmptyWhenNothingRunsThatDay() {
+        GtfsInMemoryDao dao = daoWith(trip("trip:20260810", "service-monday"),
+                List.of(new CalendarDate("service-monday", MONDAY)));
+
+        assertEquals(Optional.empty(), dao.resolveTripIdForServiceDate("trip:20260818", TUESDAY));
+        assertEquals(Optional.empty(), dao.resolveTripIdForServiceDate("unknown:trip:20260817", MONDAY));
+    }
+
+    @Test
+    void resolveTripIdForServiceDate_returnsAKnownStaticIdUnchanged() {
+        GtfsInMemoryDao dao = daoWith(trip("trip:20260810", "service-monday"),
+                List.of(new CalendarDate("service-monday", MONDAY)));
+
+        assertEquals(Optional.of("trip:20260810"), dao.resolveTripIdForServiceDate("trip:20260810", MONDAY));
+    }
+
+    @Test
+    void resolveTripIdForServiceDate_breaksTiesDeterministically() {
+        // A handful of bodies really do have two patterns active on the same day. Whichever is chosen,
+        // it must be the same one on every refresh, or delays would flip between feed reads.
+        String body = "gt:nmbssncb:BBUS__:049::8885001:8886009:3:558";
+        GtfsReader.GtfsData data = new GtfsReader.GtfsData(null, List.of(),
+                List.of(new CalendarDate("service-a", MONDAY), new CalendarDate("service-b", MONDAY)),
+                List.of(), List.of(), List.of(),
+                List.of(new Trip(body + ":20260628", "route-id", "service-b", "Brugge", 1905, 0, null),
+                        new Trip(body + ":20260621", "route-id", "service-a", "Brugge", 1905, 0, null)));
+        GtfsInMemoryDao dao = new GtfsInMemoryDao(data);
+
+        assertEquals(Optional.of(body + ":20260621"), dao.resolveTripIdForServiceDate(body + ":20260817", MONDAY));
+    }
+
+    private static Trip trip(String tripId, String serviceId) {
+        return new Trip(tripId, "route-id", serviceId, "Brussels", 1234, 0, null);
+    }
+
+    private static GtfsInMemoryDao daoWith(Trip trip, List<CalendarDate> calendarDates) {
+        return new GtfsInMemoryDao(new GtfsReader.GtfsData(
+                null, List.of(), calendarDates, List.of(), List.of(), List.of(), List.of(trip)));
     }
 }


### PR DESCRIPTION
## What
Match GTFS-RT trip ids to the schedule instead of comparing them as strings: strip the feed namespace and the trailing date, then pick the candidate whose service runs on the realtime `start_date`. Ties break on the lowest trip id. Realtime trips that match nothing are counted and logged.

## Why
The two configured feeds spell trip ids differently, so the lookup never matched:

```
static (gtfs.static.url) : gt:nmbssncb:88____:UUU::8775100:8814001:8:1834:20260810
realtime (gtfs.rt.url)   :             88____:UUU::8775100:8814001:8:2309:20260820
```

The hafas feed omits the `gt:<agency>:` namespace, and the trailing date means different things on each side — it is not the service date on either (note the realtime id ends `20260820` while its own `start_date` says `20260819`). `isCanceled` therefore returned false with no exception and no log line. On the shipped defaults, **0 of 283** realtime trips matched.

This is user-visible: `DatedVehicleJourneyV1Controller` serves `/vehicle` from GTFS plus the realtime overlay whenever the requested date is not today, so the overlay is consulted and silently applies nothing.

## What it does not fix
Same feeds, same moment: 19 of 283 trips now match, but **0 of the 215 carrying a delay or cancellation**. Those trips are absent from the static feed under any spelling — in a separate 48-trip sample, 33 of 34 misses had no counterpart at all. That is an inconsistency between the two published feeds rather than something this repository can repair, which is why the unmatched count is now logged: it is the number that should decide what happens to this feed.

`Updated GTFS-RT with <n> delay records` is preserved verbatim for tooling that greps it.

## Proof
`GtfsInMemoryDaoTest`, 8 cases: namespace and trailing-date stripping, matching across differing trailing dates, matching an id without the namespace, picking the candidate that runs that day, the two empty cases, an already-static id passing through unchanged, and deterministic tie-breaking.
