### PR TITLE
Publish the queries handled over the last minute on /v1/logs

### DIFF
--- a/src/main/java/be/irail/api/config/JerseyConfig.java
+++ b/src/main/java/be/irail/api/config/JerseyConfig.java
@@ -32,5 +32,6 @@ public class JerseyConfig extends ResourceConfig {
         register(HomeRedirectController.class);
         register(StatusController.class);
         register(IrailExceptionMapper.class);
+        register(RequestLogFilter.class);
     }
 }

--- a/src/main/java/be/irail/api/config/RequestLogFilter.java
+++ b/src/main/java/be/irail/api/config/RequestLogFilter.java
@@ -1,0 +1,75 @@
+package be.irail.api.config;
+
+import be.irail.api.db.LogQueryType;
+import be.irail.api.db.RecentQueryLog;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Records every handled API query in {@link RecentQueryLog}, so {@code /v1/logs} can report which
+ * clients are asking for what. Runs after the response has been produced and never alters it.
+ */
+@Provider
+public class RequestLogFilter implements ContainerResponseFilter {
+
+    /** Maps the final path segment of a request onto the query type reported for it. */
+    private static final Map<String, LogQueryType> QUERY_TYPE_BY_PATH = Map.of(
+            "liveboard", LogQueryType.LIVEBOARD,
+            "connections", LogQueryType.JOURNEYPLANNING,
+            "journeyplanning", LogQueryType.JOURNEYPLANNING,
+            "vehicle", LogQueryType.DATEDVEHICLEJOURNEY,
+            "stations", LogQueryType.STATIONS,
+            "composition", LogQueryType.VEHICLECOMPOSITION,
+            "disturbances", LogQueryType.SERVICEALERTS,
+            "servicealerts", LogQueryType.SERVICEALERTS
+    );
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        LogQueryType queryType = queryTypeFor(requestContext.getUriInfo().getPath());
+        if (queryType == null) {
+            // Not a data query — the logs endpoint itself, redirects, health checks and feedback posts
+            // are left out, both to avoid noise and so reading the logs cannot log itself.
+            return;
+        }
+        RecentQueryLog.getInstance().record(
+                queryType,
+                toQueryMap(requestContext.getUriInfo().getQueryParameters()),
+                requestContext.getHeaderString(HttpHeaders.USER_AGENT));
+    }
+
+    /**
+     * Resolves the query type from a request path, ignoring the API version prefix.
+     *
+     * @param path the matched request path
+     * @return the query type, or null when the path is not a data query
+     */
+    static LogQueryType queryTypeFor(String path) {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+        String trimmed = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+        int lastSegment = trimmed.lastIndexOf('/');
+        String segment = lastSegment < 0 ? trimmed : trimmed.substring(lastSegment + 1);
+        return QUERY_TYPE_BY_PATH.get(segment.toLowerCase());
+    }
+
+    /** Flattens the query parameters, keeping the first value of any repeated parameter. */
+    private static Map<String, Object> toQueryMap(MultivaluedMap<String, String> queryParameters) {
+        Map<String, Object> query = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> parameter : queryParameters.entrySet()) {
+            if (!parameter.getValue().isEmpty()) {
+                query.put(parameter.getKey(), parameter.getValue().getFirst());
+            }
+        }
+        return query;
+    }
+}

--- a/src/main/java/be/irail/api/controllers/v1/LogsV1Controller.java
+++ b/src/main/java/be/irail/api/controllers/v1/LogsV1Controller.java
@@ -1,15 +1,20 @@
 package be.irail.api.controllers.v1;
 
+import be.irail.api.db.LogEntry;
+import be.irail.api.db.LogQueryType;
+import be.irail.api.db.RecentQueryLog;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Controller for V1 Logs API endpoint.
- * Note: Full logging infrastructure (LogDao) is not yet implemented.
+ * Controller for V1 Logs API endpoint, reporting the queries handled over the last minute.
  */
 @Component
 @Path("/v1")
@@ -17,28 +22,78 @@ import java.util.Map;
 public class LogsV1Controller {
 
     /**
-     * Gets API usage logs (last 1000 entries).
+     * Gets the queries this instance handled over the last minute, newest first.
      *
-     * @return the logs as JSON
+     * <p>Only recent queries are available: they are held in memory rather than stored, so there is
+     * no history to page through. See {@link RecentQueryLog} for why.
+     *
+     * @return the recent queries as JSON
      */
     @GET
     @Path("/logs")
     public Response getLogs() {
-        // TODO: Implement when LogDao is available
-        return Response.ok("[]", "application/json;charset=UTF-8").build();
+        return Response.ok(toV1(RecentQueryLog.getInstance().getRecent())).build();
     }
 
     /**
      * Gets API usage logs for a specific date.
      *
+     * <p>Kept so the documented route does not start returning 404, but this instance holds no
+     * history — only the last minute, which {@code /v1/logs} serves. Always an empty list.
+     *
      * @param date the date in yyyyMMdd format
-     * @return the logs as JSON
+     * @return an empty list
      */
     @GET
     @Path("/logs/{date}")
     public Response getLogsForDate(@PathParam("date") String date) {
-        // TODO: Implement when LogDao is available
-        return Response.ok("[]", "application/json;charset=UTF-8").build();
+        return Response.ok(List.of()).build();
+    }
+
+    /**
+     * Converts entries to the shape the PHP implementation served, so existing consumers of this
+     * endpoint keep working.
+     *
+     * @param entries the entries to convert, newest first
+     * @return the entries as V1 maps
+     */
+    private static List<Map<String, Object>> toV1(List<LogEntry> entries) {
+        List<Map<String, Object>> result = new ArrayList<>(entries.size());
+        for (LogEntry entry : entries) {
+            Map<String, Object> query = new LinkedHashMap<>(entry.getQuery());
+            if (entry.getResult() != null) {
+                query.putAll(entry.getResult());
+            }
+            Map<String, Object> converted = new LinkedHashMap<>();
+            converted.put("querytype", v1Name(entry.getQueryType()));
+            converted.put("querytime", entry.getCreatedAt().toString());
+            converted.put("query", query);
+            converted.put("user_agent", entry.getUserAgent());
+            result.add(converted);
+        }
+        return result;
+    }
+
+    /**
+     * The name this query type is published under.
+     *
+     * <p>Three of these differ from {@link LogQueryType#getValue()}, which carries the upstream
+     * NMBS wording: the V1 API has always published {@code Connections},
+     * {@code VehicleInformation} and {@code Disturbances}. Using the enum value here would silently
+     * rename them for every existing consumer.
+     *
+     * @param queryType the internal query type
+     * @return the name used in the V1 response
+     */
+    static String v1Name(LogQueryType queryType) {
+        return switch (queryType) {
+            case LIVEBOARD -> "Liveboard";
+            case JOURNEYPLANNING -> "Connections";
+            case DATEDVEHICLEJOURNEY -> "VehicleInformation";
+            case VEHICLECOMPOSITION -> "Composition";
+            case STATIONS -> "Stations";
+            case SERVICEALERTS -> "Disturbances";
+        };
     }
 
     /**

--- a/src/main/java/be/irail/api/db/RecentQueryLog.java
+++ b/src/main/java/be/irail/api/db/RecentQueryLog.java
@@ -1,0 +1,107 @@
+package be.irail.api.db;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The most recent API queries, kept in memory only.
+ *
+ * <p>Deliberately not backed by the database. The previous PHP implementation wrote a row per
+ * request and was switched off in {@code 08776cef} for "risking the stability of the overall API";
+ * at the current peak of roughly 100 requests per second an insert per request would put the same
+ * pressure back on a database that also serves station lookups. A bounded in-memory window costs
+ * nothing per request, cannot grow without limit, and is exactly what a "recent queries" endpoint
+ * needs — nobody reads this to learn what happened last week.
+ *
+ * <p>Entries are dropped once they fall outside {@link #RETENTION}, and {@link #MAX_ENTRIES} caps
+ * memory should traffic spike far beyond the expected peak. Nothing here identifies a caller
+ * personally: no IP address is recorded, only the query itself and the User-Agent it arrived with.
+ */
+public class RecentQueryLog {
+
+    /** How far back the endpoint reports. */
+    private static final Duration RETENTION = Duration.ofMinutes(1);
+
+    /**
+     * Hard ceiling on retained entries, independent of {@link #RETENTION}. One minute at the
+     * expected peak is roughly 6 000 entries, so this leaves headroom without letting an
+     * unexpected burst hold an unbounded amount of memory.
+     */
+    private static final int MAX_ENTRIES = 10_000;
+
+    private static final RecentQueryLog INSTANCE = new RecentQueryLog();
+
+    private final Deque<LogEntry> entries = new ConcurrentLinkedDeque<>();
+    private final AtomicInteger sequence = new AtomicInteger();
+
+    private RecentQueryLog() {
+    }
+
+    public static RecentQueryLog getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Records one handled query.
+     *
+     * @param queryType the kind of query that was served
+     * @param query     the request parameters
+     * @param userAgent the User-Agent the request arrived with, may be null
+     */
+    public void record(LogQueryType queryType, Map<String, Object> query, String userAgent) {
+        record(queryType, query, userAgent, OffsetDateTime.now());
+    }
+
+    /**
+     * Records one handled query at an explicit time, so ageing out can be exercised in tests.
+     *
+     * @param queryType the kind of query that was served
+     * @param query     the request parameters
+     * @param userAgent the User-Agent the request arrived with, may be null
+     * @param handledAt when the query was handled
+     */
+    void record(LogQueryType queryType, Map<String, Object> query, String userAgent, OffsetDateTime handledAt) {
+        entries.addLast(new LogEntry(sequence.incrementAndGet(), queryType, query, Map.of(), userAgent, handledAt));
+        evictExpired();
+    }
+
+    /**
+     * The queries handled within the retention window, newest first.
+     *
+     * @return the retained entries, most recent first
+     */
+    public List<LogEntry> getRecent() {
+        evictExpired();
+        List<LogEntry> recent = new ArrayList<>(entries);
+        return recent.reversed();
+    }
+
+    /** Drops entries that have aged out, then trims to the size ceiling. */
+    private void evictExpired() {
+        OffsetDateTime cutoff = OffsetDateTime.now().minus(RETENTION);
+        // Entries are appended in order, so everything older sits at the head.
+        for (LogEntry oldest = entries.peekFirst();
+             oldest != null && oldest.getCreatedAt().isBefore(cutoff);
+             oldest = entries.peekFirst()) {
+            if (!entries.remove(oldest)) {
+                break;
+            }
+        }
+        while (entries.size() > MAX_ENTRIES) {
+            if (entries.pollFirst() == null) {
+                break;
+            }
+        }
+    }
+
+    /** Discards every retained entry. Intended for tests. */
+    public void clear() {
+        entries.clear();
+    }
+}

--- a/src/test/java/be/irail/api/config/RequestLogFilterTest.java
+++ b/src/test/java/be/irail/api/config/RequestLogFilterTest.java
@@ -1,0 +1,59 @@
+package be.irail.api.config;
+
+import be.irail.api.db.LogQueryType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RequestLogFilterTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "v1/liveboard,      LIVEBOARD",
+            "v1/connections,    JOURNEYPLANNING",
+            "v1/vehicle,        DATEDVEHICLEJOURNEY",
+            "v1/stations,       STATIONS",
+            "v1/composition,    VEHICLECOMPOSITION",
+            "v1/disturbances,   SERVICEALERTS",
+    })
+    void recognisesTheV1DataQueries(String path, LogQueryType expected) {
+        assertEquals(expected, RequestLogFilter.queryTypeFor(path));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "v2/liveboard,          LIVEBOARD",
+            "v2/journeyplanning,    JOURNEYPLANNING",
+            "v2/servicealerts,      SERVICEALERTS",
+    })
+    void recognisesTheV2NamesToo(String path, LogQueryType expected) {
+        assertEquals(expected, RequestLogFilter.queryTypeFor(path));
+    }
+
+    @Test
+    void ignoresTheLogsEndpointSoReadingLogsDoesNotLogItself() {
+        assertNull(RequestLogFilter.queryTypeFor("v1/logs"));
+        assertNull(RequestLogFilter.queryTypeFor("v1/logs/20260819"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/", "v1", "health", "v1/feedback/occupancy", "favicon.ico"})
+    void ignoresEverythingThatIsNotADataQuery(String path) {
+        assertNull(RequestLogFilter.queryTypeFor(path));
+    }
+
+    @Test
+    void ignoresANullPath() {
+        assertNull(RequestLogFilter.queryTypeFor(null));
+    }
+
+    @Test
+    void toleratesATrailingSlashAndCasing() {
+        assertEquals(LogQueryType.LIVEBOARD, RequestLogFilter.queryTypeFor("v1/liveboard/"));
+        assertEquals(LogQueryType.LIVEBOARD, RequestLogFilter.queryTypeFor("v1/Liveboard"));
+    }
+}

--- a/src/test/java/be/irail/api/controllers/v1/LogsV1ControllerTest.java
+++ b/src/test/java/be/irail/api/controllers/v1/LogsV1ControllerTest.java
@@ -1,0 +1,31 @@
+package be.irail.api.controllers.v1;
+
+import be.irail.api.db.LogQueryType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class LogsV1ControllerTest {
+
+    @Test
+    void publishesTheNamesV1HasAlwaysUsed() {
+        // Three of these differ from LogQueryType.getValue(), which carries the upstream NMBS wording.
+        // Publishing the enum value instead would silently rename them for every existing consumer.
+        assertEquals("Connections", LogsV1Controller.v1Name(LogQueryType.JOURNEYPLANNING));
+        assertEquals("VehicleInformation", LogsV1Controller.v1Name(LogQueryType.DATEDVEHICLEJOURNEY));
+        assertEquals("Disturbances", LogsV1Controller.v1Name(LogQueryType.SERVICEALERTS));
+
+        assertEquals("Liveboard", LogsV1Controller.v1Name(LogQueryType.LIVEBOARD));
+        assertEquals("Composition", LogsV1Controller.v1Name(LogQueryType.VEHICLECOMPOSITION));
+        assertEquals("Stations", LogsV1Controller.v1Name(LogQueryType.STATIONS));
+    }
+
+    @ParameterizedTest
+    @EnumSource(LogQueryType.class)
+    void everyQueryTypeHasAPublishedName(LogQueryType queryType) {
+        assertNotNull(LogsV1Controller.v1Name(queryType));
+    }
+}

--- a/src/test/java/be/irail/api/controllers/v1/LogsV1EndToEndTest.java
+++ b/src/test/java/be/irail/api/controllers/v1/LogsV1EndToEndTest.java
@@ -1,0 +1,72 @@
+package be.irail.api.controllers.v1;
+
+import be.irail.api.db.RecentQueryLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves the request filter is actually registered and fires. The unit tests cover the path
+ * mapping in isolation, which would still pass if the filter were never wired into Jersey at
+ * all — the failure mode this endpoint would most plausibly ship with.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class LogsV1EndToEndTest {
+
+    @LocalServerPort
+    private int port;
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    @BeforeEach
+    void reset() {
+        RecentQueryLog.getInstance().clear();
+    }
+
+    @Test
+    void aHandledQueryShowsUpInTheLogsEndpoint() throws Exception {
+        get("/v1/stations?format=json", "IntegrationTestAgent/1.0");
+
+        List<Map<String, Object>> logs = RecentQueryLog.getInstance().getRecent().stream()
+                .map(entry -> Map.<String, Object>of(
+                        "querytype", LogsV1Controller.v1Name(entry.getQueryType()),
+                        "user_agent", String.valueOf(entry.getUserAgent())))
+                .toList();
+
+        assertFalse(logs.isEmpty(), "the stations query should have been recorded by the filter");
+        assertEquals("Stations", logs.getFirst().get("querytype"));
+        assertEquals("IntegrationTestAgent/1.0", logs.getFirst().get("user_agent"));
+    }
+
+    @Test
+    void readingTheLogsDoesNotRecordItself() throws Exception {
+        get("/v1/logs", "IntegrationTestAgent/1.0");
+        get("/v1/logs", "IntegrationTestAgent/1.0");
+
+        assertTrue(RecentQueryLog.getInstance().getRecent().isEmpty(),
+                "requests to the logs endpoint must not appear in the logs");
+    }
+
+    private void get(String path, String userAgent) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + path))
+                .header("User-Agent", userAgent)
+                .GET()
+                .build();
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/test/java/be/irail/api/db/RecentQueryLogTest.java
+++ b/src/test/java/be/irail/api/db/RecentQueryLogTest.java
@@ -1,0 +1,73 @@
+package be.irail.api.db;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecentQueryLogTest {
+
+    private final RecentQueryLog log = RecentQueryLog.getInstance();
+
+    @BeforeEach
+    void reset() {
+        log.clear();
+    }
+
+    @Test
+    void reportsNewestFirst() {
+        log.record(LogQueryType.LIVEBOARD, Map.of("station", "Brussel-Zuid"), "first");
+        log.record(LogQueryType.STATIONS, Map.of(), "second");
+
+        List<LogEntry> recent = log.getRecent();
+
+        assertEquals(2, recent.size());
+        assertEquals("second", recent.getFirst().getUserAgent());
+        assertEquals("first", recent.getLast().getUserAgent());
+    }
+
+    @Test
+    void keepsTheQueryAndUserAgentItWasGiven() {
+        log.record(LogQueryType.JOURNEYPLANNING, Map.of("from", "Gent", "to", "Brugge"), "BeTrains/1.0");
+
+        LogEntry entry = log.getRecent().getFirst();
+
+        assertEquals(LogQueryType.JOURNEYPLANNING, entry.getQueryType());
+        assertEquals(Map.of("from", "Gent", "to", "Brugge"), entry.getQuery());
+        assertEquals("BeTrains/1.0", entry.getUserAgent());
+    }
+
+    @Test
+    void agesOutEntriesOlderThanTheRetentionWindow() {
+        log.record(LogQueryType.LIVEBOARD, Map.of(), "stale", OffsetDateTime.now().minusMinutes(5));
+        log.record(LogQueryType.LIVEBOARD, Map.of(), "fresh");
+
+        List<LogEntry> recent = log.getRecent();
+
+        assertEquals(1, recent.size(), "the five-minute-old entry should have aged out");
+        assertEquals("fresh", recent.getFirst().getUserAgent());
+    }
+
+    @Test
+    void toleratesANullUserAgent() {
+        log.record(LogQueryType.STATIONS, Map.of(), null);
+
+        assertEquals(1, log.getRecent().size());
+    }
+
+    @Test
+    void staysBoundedUnderABurstFarBeyondTheExpectedPeak() {
+        // A minute at ~100 req/s is roughly 6 000 entries; this pushes well past that to confirm the
+        // ceiling holds, since the whole point of keeping this in memory is that it cannot run away.
+        for (int i = 0; i < 25_000; i++) {
+            log.record(LogQueryType.LIVEBOARD, Map.of("station", "Brussel-Zuid"), "burst");
+        }
+
+        assertTrue(log.getRecent().size() <= 10_000, "retained entries must stay under the ceiling");
+    }
+}


### PR DESCRIPTION
Fixes #594.

## What
Records each handled query and serves the last minute of them on `/v1/logs`, in the shape the PHP implementation used.

## Why
The route returned a hardcoded `[]` and nothing recorded requests, so there was no way to see which clients call iRail or with what parameters.

Kept in memory rather than in the database: the PHP version wrote a row per request and was disabled in `08776cef` for "risking the stability of the overall API". At roughly 100 requests/second peak that pressure would land on a database that also serves station lookups. Entries age out after a minute, with a hard ceiling so a burst cannot hold unbounded memory.

Two details:
- Three query type names differ from `LogQueryType.getValue()` — `Connections`, `VehicleInformation`, `Disturbances`. Publishing the enum value instead would silently rename them for existing consumers.
- No IP address is recorded, only the query and its User-Agent. `/v1/logs/{date}` still answers, with an empty list, since no history is retained.

## Proof
33 new cases: `RequestLogFilterTest` (path to query type, including that `/v1/logs` is excluded so reading logs does not log itself), `RecentQueryLogTest` (ordering, ageing out, the size ceiling under a burst), `LogsV1ControllerTest` (the published names), and `LogsV1EndToEndTest`, which boots the app and asserts a real request is recorded — the unit tests would pass even if the filter were never registered.
